### PR TITLE
Filter php files

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -46,13 +46,17 @@ class Loader
         $fixtures = array();
         $includedFiles = array();
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::LEAVES_ONLY
+        $iterator = new \RegexIterator(
+        	new \RecursiveIteratorIterator(
+            	new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            	\RecursiveIteratorIterator::LEAVES_ONLY
+            ),
+            '/^.+\.php$/i',
+            \RecursiveRegexIterator::GET_MATCH
         );
 
         foreach ($iterator as $file) {
-            $sourceFile = realpath($file->getPathName());
+            $sourceFile = realpath($file[0]);
             require_once $sourceFile;
             $includedFiles[] = $sourceFile;
         }


### PR DESCRIPTION
Hi,
I ran into problems using the data fixtures in my SVN-managed project because of all the files in the hidden ".svn" directory. Some of these files were valid PHP files containing already defined classes, so I got a fatal error when loading the fixtures. This patch makes the loader to search only for *.php files.
