### PR TITLE
Dramatically improve fixture loading performances.

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
@@ -60,6 +60,7 @@ abstract class AbstractExecutor
             $this->log('loading ' . get_class($fixture));
         }
         $fixture->load($manager);
+        $manager->clear();
     }
 
     /**


### PR DESCRIPTION
Especially on large projects that have a lot of fixture files.
It's just about clearing the manager between two files.
