### PR TITLE
Change to use truncate for purging instead of delete

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -83,7 +83,8 @@ class ORMPurger implements PurgerInterface
         }
 
         foreach($orderedTables as $tbl) {
-            $this->em->getConnection()->executeUpdate("DELETE FROM $tbl");
+            $sql = $this->em->getConnection()->getDatabasePlatform()->getTruncateTableSQL($tbl);
+            $this->em->getConnection()->executeUpdate($sql);
         }
     }
 


### PR DESCRIPTION
Instead of the purger using DELETE FROM it now grabs the getTruncateTableSQL from the Platform class, ie TRUNCATE TABLE.

This make the library much better for testing as auto increment keys can be known.
