### PR TITLE
Use TRUNCATE...CASCADE to purge the database when reloading the fixtures.

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -84,7 +84,7 @@ class ORMPurger implements PurgerInterface
 
         $platform = $this->em->getConnection()->getDatabasePlatform();
         foreach($orderedTables as $tbl) {
-            $this->em->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl));
+            $this->em->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
         }
     }
 


### PR DESCRIPTION
Use TRUNCATE...CASCADE to purge the database when reloading the fixtures. Otherwise the command is failing when trying to purge a table with foreign keys.
