### PR TITLE
check to see if file exists before attempting require_once in Loader

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -89,8 +89,10 @@ class Loader
                 continue;
             }
             $sourceFile = realpath($file->getPathName());
-            require_once $sourceFile;
-            $includedFiles[] = $sourceFile;
+            if (file_exists($sourceFile)) {
+                require_once $sourceFile;
+                $includedFiles[] = $sourceFile;
+            }
         }
         $declared = get_declared_classes();
         


### PR DESCRIPTION
this skips over files that are obviously not meant to be required,
such as temp files from editors when a file is open in a datafixtures
directory with unsaved changes in it, while preserving the "shut
down everything" behaviour of "require".

I figure that script-halting behavior could actually be beneficial here,
and that that's why you're not using include_once. If the behavior of
file_exists wrt safe_mode is a problem, there are other ways of checking.