### PR TITLE
Fix getting identifier based on Entity or ODM

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -76,11 +76,11 @@ class ReferenceRepository
         // in case if reference is set after flush, store its identity
         $uow = $this->manager->getUnitOfWork();
         if ($uow->isInIdentityMap($reference)) {
-            if (method_exists($uow, 'getEntityIdentifier')) {
+            if ($uow instanceof \Doctrine\ORM\UnitOfWork) {
                 $this->identities[$name] = $uow->getEntityIdentifier($reference);
-            } elseif (method_exists($uow, 'getDocumentIdentifier')) {
-                $this->identities[$name] = $uow->getDocumentIdentifier($reference);            
-            }
+            } else {
+                $this->identities[$name] = $uow->getDocumentIdentifier($reference);
+            }            
         }
     }
 


### PR DESCRIPTION
The ReferenceRepository assumes the Unit Of Work is an ORM one, so it tries to fetch an EntityIdentifier. If the UOW is based on ODM, this fails of course. 

This was the simplest fix i found, but might not be the way you like to fix this problem. 

Following the symfony cookbook at http://symfony.com/doc/current/cookbook/doctrine/doctrine_fixtures.html with using mongodb as database will result in this error : 
Fatal error: Call to undefined method Doctrine\ODM\MongoDB\UnitOfWork::getEntityIdentifier() in ../vendor/doctrine-fixtures/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php on line 79
