### PR TITLE
Issue #17

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -83,8 +83,14 @@ class ORMPurger implements PurgerInterface
         }
 
         $platform = $this->em->getConnection()->getDatabasePlatform();
+        if(get_class($platform) == 'Doctrine\\DBAL\\Platforms\\MySqlPlatform') {
+            $this->em->getConnection()->executeQuery("SET foreign_key_checks = 0;");
+        }
         foreach($orderedTables as $tbl) {
             $this->em->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+        }
+        if(get_class($platform) == 'Doctrine\\DBAL\\Platforms\\MySqlPlatform') {
+            $this->em->getConnection()->executeQuery("SET foreign_key_checks = 1;");
         }
     }
 


### PR DESCRIPTION
Hi,

I found that the problem only occurs with InnoDB tables (with FKs) on MySQL since 5.5.7. I made a patch to remove this MySQL check during purge. I reset that var after (anyway foreign_key_checks is not persistent)

I hope it will help

PS: mysqldump seems to do the same thing automatically when importing a backup.
