### PR TITLE
added hasReference method

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -87,4 +87,17 @@ abstract class AbstractFixture implements SharedFixtureInterface
     {
         return $this->referenceRepository->getReference($name);
     }
+    
+    /**
+     * Check if an object is stored using reference
+     * named by $name
+     * 
+     * @param string $name
+     * @see Doctrine\Common\DataFixtures\ReferenceRepository::hasReference
+     * @return boolean
+     */
+    public function hasReference($name)
+    {
+        return $this->referenceRepository->hasReference($name);
+    }
 }

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -137,6 +137,18 @@ class ReferenceRepository
     }
 
     /**
+     * Check if an object is stored using reference
+     * named by $name
+     *
+     * @param string $name
+     * @return boolean
+     */
+    public function hasReference($name)
+    {
+        return isset($this->references[$name]);
+    }
+
+    /**
      * Searches for a reference name in the
      * list of stored references
      *


### PR DESCRIPTION
Since calling getReference with a non-existant key throws an PHP Notice either that notice needs to be avoid with an isset or following this pull request we could use hasReference to check before using get.
