### PR TITLE
Adds order in log message when loading fixtures

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
@@ -4,6 +4,7 @@ namespace Doctrine\Common\DataFixtures\Executor;
 
 use Doctrine\Common\DataFixtures\SharedFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Common\DataFixtures\ReferenceRepository;
 
 /**
@@ -85,7 +86,11 @@ abstract class AbstractExecutor
     public function load($manager, FixtureInterface $fixture)
     {
         if ($this->logger) {
-            $this->log('loading ' . get_class($fixture));
+            $prefix = '';
+            if ($fixture instanceof OrderedFixtureInterface) {
+                $prefix = sprintf('[%d] ',$fixture->getOrder());
+            }
+            $this->log('loading ' . $prefix . get_class($fixture));
         }
         // additionaly pass the instance of reference repository to shared fixtures
         if ($fixture instanceof SharedFixtureInterface) {


### PR DESCRIPTION
More fancy output:

```
  > purging database
  > loading LoadUnorderData
  > loading [10] LoadEntity1Data
  > loading [11] LoadEntity2Data
  > loading [20] LoadEntity3Data
```
