### PR TITLE
spedified param $method of interface FixturesInterface

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\Common\DataFixtures;
 
+use Doctrine\ORM\EntityManager;
+
 /**
  * Interface contract for fixture classes to implement.
  *
@@ -29,7 +31,7 @@ interface FixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      *
-     * @param object $manager
+     * @param EntityManager $manager
      */
-    function load($manager);
+    function load(EntityManager $manager);
 }


### PR DESCRIPTION
Is it right to specify that param $manager of method load() is type of Doctrine\ORM\EntityManager?
