### PR TITLE
Add ability to exclude tables in purge

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Saem Ghani
  */
 class ORMPurger implements PurgerInterface
 {
@@ -36,6 +37,9 @@ class ORMPurger implements PurgerInterface
 
     /** EntityManager instance used for persistence. */
     private $em;
+
+    /** @var array An array of table names to ignore */
+    private $excludedTables = array();
 
     /**
      * If the purge should be done through DELETE or TRUNCATE statements
@@ -48,10 +52,12 @@ class ORMPurger implements PurgerInterface
      * Construct new purger instance.
      *
      * @param EntityManager $em EntityManager instance used for persistence.
+     * @param array $excludedTables tables to be excluded from the purge
      */
-    public function __construct(EntityManager $em = null)
+    public function __construct(EntityManager $em = null, array $excludedTables = array())
     {
         $this->em = $em;
+        $this->setExcludedTables($excludedTables);
     }
 
     /**
@@ -85,6 +91,16 @@ class ORMPurger implements PurgerInterface
       $this->em = $em;
     }
 
+    /**
+     * Set the classes to be ignored during the purge
+     *
+     * @param array $excludedTables An array of class names to ignore
+     */
+    public function setExcludedTables(array $excludedTables = array())
+    {
+        $this->excludedTables = ($excludedTables) ? array_flip($excludedTables) : array();
+    }
+
     /** @inheritDoc */
     public function purge()
     {
@@ -116,6 +132,9 @@ class ORMPurger implements PurgerInterface
 
         $platform = $this->em->getConnection()->getDatabasePlatform();
         foreach($orderedTables as $tbl) {
+            if (isset($this->excludedTables[$tbl])) {
+                continue;
+            }
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                 $this->em->getConnection()->executeUpdate("DELETE FROM " . $tbl);
             } else {

--- a/tests/Doctrine/Tests/Common/DataFixtures/BaseTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/BaseTest.php
@@ -29,6 +29,7 @@ use PHPUnit_Framework_TestCase;
  * Base test class
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
+ * @author Saem Ghani
  */
 abstract class BaseTest extends PHPUnit_Framework_TestCase
 {
@@ -57,8 +58,14 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
             ->method('getMetadataDriverImpl')
             ->will($this->returnValue($this->getMock('Doctrine\ORM\Mapping\Driver\DriverChain')));
 
-        $em = EntityManager::create($conn, $config);
-        return $em;
+        $metadataFactory = $this->getMock('\Doctrine\ORM\Mapping\ClassMetadataFactory');
+        $metadataFactoryName = get_class($metadataFactory);
+
+        $config->expects($this->once())
+            ->method('getClassMetadataFactoryName')
+            ->will($this->returnValue($metadataFactoryName));
+
+        return EntityManager::create($conn, $config);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -1,0 +1,152 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\Common\DataFixtures\Purger;
+
+use Doctrine\Tests\Common\DataFixtures\BaseTest;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+
+require_once __DIR__.'/../TestInit.php';
+
+/**
+ * Test ORMPurger
+ *
+ * @author Saem Ghani
+ */
+class ORMPurgerTest extends BaseTest
+{
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    protected function setUp()
+    {
+        $this->em = $this->getMockEntityManager();
+    }
+
+    /**
+     * @test
+     */
+    public function purgerWhichDefaultsToDeleteMode()
+    {
+        $metadataFactory = $this->em->getMetadataFactory();
+        $metadataFactory->expects($this->once())->method('getAllMetadata')->will($this->returnValue(array($this->getRoleTableMetaData())));
+
+        $this->em->getConnection()->expects($this->once())->method('executeUpdate')->with($this->stringStartsWith('DELETE FROM Role'));
+
+        $purger = new ORMPurger($this->em);
+        $purger->purge();
+    }
+
+    /**
+     * @test
+     */
+    public function purgerWhichCanBeSetToTruncateMode()
+    {
+        $metadataFactory = $this->em->getMetadataFactory();
+        $metadataFactory->expects($this->once())->method('getAllMetadata')->will($this->returnValue(array($this->getRoleTableMetaData())));
+
+        $platform = $this->getMock('\Doctrine\Tests\DBAL\Mocks\MockPlatform', array('getTruncateTableSQL'));
+        $platform->expects($this->once())->method('getTruncateTableSQL')->with($this->equalTo('Role'))->will($this->returnValue('FOO'));
+        $this->em->getConnection()
+            ->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->will($this->returnValue($platform));
+        $this->em->getConnection()->expects($this->once())->method('executeUpdate')->with($this->stringStartsWith('FOO'));
+
+        $purger = new ORMPurger($this->em);
+        $purger->setPurgeMode(ORMPurger::PURGE_MODE_TRUNCATE);
+        $purger->purge();
+    }
+
+    /**
+     * @test
+     */
+    public function theEntityManagerCanBeSetAfterConstruction()
+    {
+        $metadataFactory = $this->em->getMetadataFactory();
+        $metadataFactory->expects($this->once())->method('getAllMetadata')->will($this->returnValue(array($this->getRoleTableMetaData())));
+
+        $this->em->getConnection()->expects($this->once())->method('executeUpdate')->with($this->stringStartsWith('DELETE FROM Role'));
+
+        $purger = new ORMPurger();
+        $purger->setEntityManager($this->em);
+        $purger->purge();
+    }
+
+    /**
+     * @test
+     */
+    public function thePurgerWillPurgeAssociatedEntities()
+    {
+        $metadataFactory = $this->em->getMetadataFactory();
+        $metadataFactory->expects($this->once())->method('getAllMetadata')->will($this->returnValue(array($this->getUserTableMetaData())));
+
+        $this->em->getConnection()->expects($this->at(1))->method('executeUpdate')->with($this->stringStartsWith('DELETE FROM User'));
+        $this->em->getConnection()->expects($this->at(2))->method('executeUpdate')->with($this->stringStartsWith('DELETE FROM Role'));
+
+        $purger = new ORMPurger($this->em);
+        $purger->purge();
+    }
+
+    /**
+     * @test
+     */
+    public function thePurgerCanDoSelectivePurges()
+    {
+        $metadataFactory = $this->em->getMetadataFactory();
+        $metadataFactory->expects($this->once())->method('getAllMetadata')->will($this->returnValue(array($this->getUserTableMetaData())));
+
+        $this->em->getConnection()->expects($this->once())->method('executeUpdate')->with($this->stringStartsWith('DELETE FROM User'));
+
+        $purger = new ORMPurger($this->em, array('Role'));
+        $purger->purge();
+    }
+
+    private function getUserTableMetaData()
+    {
+        $role = $this->getRoleTableMetaData();
+        $this->em->getMetadataFactory()->expects($this->once())->method('getMetaDataFor')->will($this->returnValue($role));
+        $user = $this->createMetadata('User');
+        $user->associationMappings = array(array(
+            'isOwningSide' => true,
+            'type' => \Doctrine\ORM\Mapping\ClassMetadata::ONE_TO_MANY,
+            'targetEntity' => $role
+        ));
+        return $user;
+    }
+
+    private function getRoleTableMetaData()
+    {
+        return $this->createMetadata('Role');
+    }
+
+    private function createMetadata($name)
+    {
+        $metadata = $this->getMock('\Doctrine\ORM\Mapping\ClassMetaData', array(), array(), '', false);
+        $metadata->name = $name;
+        $metadata->isMappedSuperclass = false;
+        $metadata->associationMappings = array();
+        $metadata->expects($this->once())->method('isInheritanceTypeSingleTable')->will($this->returnValue(false));
+        $metadata->expects($this->once())->method('getTableName')->will($this->returnValue($name));
+
+        return $metadata;
+    }
+}


### PR DESCRIPTION
At work we manage our database change sets through [Liquibase](http://liquibase.org/) (this isn't negotiable). We require fixtures to load test data. The database is initialized (both structure and seed data) via Liquibase.

After which we'd like to load fixture data for running integration tests with, having consistent test data for all of our developers, and standardized data for manual regression testing. The problem is if we have any pre-seeded dictionaries in the database (we have a few), which are referenced by our entities, they get deleted/truncated (well not truncated since it doesn't work in newer versions of mysql). Rather than duplicating the fixtures into doctrine from liquibase, or some other hack. It'd be ideal if we could simply provide the purger with a suppression/exclusion list.

I've added basic purger tests, and an initial implementation and test case for this.
