### PR TITLE
Missing use statement in lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -22,6 +22,7 @@ namespace Doctrine\Common\DataFixtures\Executor;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener;
+use Doctrine\Common\DataFixtures\ReferenceRepository;
 
 /**
  * Class responsible for executing data fixtures.


### PR DESCRIPTION
there was a missing use statement here
