### PR TITLE
Import namespace Doctrine\Common\DataFixtures\ReferenceRepository to rem...

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -21,6 +21,7 @@ namespace Doctrine\Common\DataFixtures\Executor;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener;
 
 /**


### PR DESCRIPTION
...ove PHP Strict Standard Error "Declaration of Doctrine\Common\DataFixtures\Executor\ORMExecutor::setReferenceRepository() should be compatible with that of Doctrine\Common\DataFixtures\Executor\AbstractExecutor::setReferenceRepository()".
