### PR TITLE
Update lib/Doctrine/Common/DataFixtures/Executor/MongoDBExecutor.php

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/MongoDBExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/MongoDBExecutor.php
@@ -76,6 +76,7 @@ class MongoDBExecutor extends AbstractExecutor
     {
         if ($append === false) {
             $this->purge();
+            $this->getObjectManager()->getSchemaManager()->updateIndexes();
         }
         foreach ($fixtures as $fixture) {
             $this->load($this->dm, $fixture);


### PR DESCRIPTION
When loading fixtures with MongoDB the indexes are getting dropped on purging the collections.

Added the proper command to update the Indexes right after the purging, to ensure consistency