### PR TITLE
Fixed error in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Provide an array of fixture class names:
         public function load(ObjectManager $manager)
         {}
 
-        public function getDepends()
+        public function getDependencies()
         {
             return array('MyDataFixtures\MyOtherFixture'); // fixture classes fixture is dependent on
         }


### PR DESCRIPTION
The section regarding DependentFixtureInterface says that you should implement the method 'getDepends' but the actual method name is 'getDependencies'.
