### PR TITLE
Method for loading fixtures from file added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ You can load a set of fixtures from a directory as well:
 
     $loader->loadFromDirectory('/path/to/MyDataFixtures');
 
+Or you can load a set of fixtures from a file:
+
+    $loader->loadFromFile('/path/to/MyDataFixtures/MyFixture1.php');
+
 You can get the added fixtures using the getFixtures() method:
 
     $fixtures = $loader->getFixtures();

--- a/tests/Doctrine/Tests/Common/DataFixtures/LoaderTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/LoaderTest.php
@@ -30,7 +30,7 @@ use Doctrine\Common\DataFixtures\Loader;
  */
 class LoaderTest extends BaseTest
 {
-    public function testLoader()
+    public function testLoadFromDirectory()
     {
         $loader = new Loader();
         $loader->addFixture($this->getMock('Doctrine\Common\DataFixtures\FixtureInterface'), array(), array(), 'Mock1');
@@ -41,6 +41,25 @@ class LoaderTest extends BaseTest
 
         $loader->loadFromDirectory(__DIR__.'/TestFixtures');
         $this->assertCount(7, $loader->getFixtures());
+        $this->assertTrue($loader->isTransient('TestFixtures\NotAFixture'));
+        $this->assertFalse($loader->isTransient('TestFixtures\MyFixture1'));
+    }
+
+    public function testLoadFromFile()
+    {
+        $loader = new Loader();
+        $loader->addFixture($this->getMock('Doctrine\Common\DataFixtures\FixtureInterface'), array(), array(), 'Mock1');
+        $loader->addFixture($this->getMock('Doctrine\Common\DataFixtures\FixtureInterface', array(), array(), 'Mock2'));
+        $loader->addFixture($this->getMock('Doctrine\Common\DataFixtures\SharedFixtureInterface', array(), array(), 'Mock3'));
+
+        $this->assertCount(3, $loader->getFixtures());
+
+        $loader->loadFromFile(__DIR__.'/TestFixtures/MyFixture1.php');
+        $this->assertCount(4, $loader->getFixtures());
+        $loader->loadFromFile(__DIR__.'/TestFixtures/NotAFixture.php');
+        $this->assertCount(4, $loader->getFixtures());
+        $loader->loadFromFile(__DIR__.'/TestFixtures/MyFixture2.php');
+        $this->assertCount(5, $loader->getFixtures());
         $this->assertTrue($loader->isTransient('TestFixtures\NotAFixture'));
         $this->assertFalse($loader->isTransient('TestFixtures\MyFixture1'));
     }


### PR DESCRIPTION
This PR allows to load fixtures from a single file by adding `loadFromFile` method to `Loader` class.

In some projects which require various fixture sets (e.g. for different setups for various environments) being able to point fixtures only by directory is quite a pain as some fixtures may be reused in few sets. Moving them to subdirectories doesn't solve the problem in some cases as namespaces would have to be adjusted accordingly. There were some issues reported concerning the lack of this feature both in this repo and in DoctrineFixturesBundle. They didn't however contain any code needed to accomplish the goal.

I am planning also to provide a related PR to DoctrineFixturesBundle when this one meets your acceptance.

PHPUnit tests fail in one case, but it does not seem related and it fails also on `master`. Namely:
```
There was 1 failure:

1) Doctrine\Tests\Common\DataFixtures\ProxyReferenceRepositoryTest::testReferenceReconstruction
Failed asserting that Doctrine\Tests\Common\DataFixtures\TestEntity\Role Object (...) is an instance of class "Doctrine\ORM\Proxy\Proxy".

/home/mariusz/Development/data-fixtures/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php:116
```