### PR TITLE
Dependent fixtures autoloading when using CLI command

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -138,6 +138,9 @@ class Loader
                 $this->orderFixturesByNumber = true;
             } elseif ($fixture instanceof DependentFixtureInterface) {
                 $this->orderFixturesByDependencies = true;
+                foreach($fixture->getDependencies() as $class) {
+                    $this->addFixture(new $class);
+                }
             }
 
             $this->fixtures[$fixtureClass] = $fixture;


### PR DESCRIPTION
When using the cli doctrine:fixtures:load command with the --fixtures parameter, the dependent fixture could not be loaded with RuntimeException

```
Fixture "<dependentFixtureName>" was declared as a dependency, but it should be added in fixture loader first.
```

This commit will add each dependent fixture to the loader.
