### PR TITLE
Change accessibility of referenceRepository to protected

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -35,7 +35,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      * 
      * @var ReferenceRepository
      */
-    private $referenceRepository;
+    protected $referenceRepository;
     
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This allows to use `$this->referenceRepository` in subclasses of `AbstractFixtures`.

Check here for an exemple: https://github.com/KnpLabs/geekweek12/pull/18
