### PR TITLE
On doctrine:fixtures:load if data-fixtures cannot get a reference will f...

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -142,6 +142,9 @@ class ReferenceRepository
      */
     public function getReference($name)
     {
+        if (empty($this->references[$name])) {
+            throw new \Exception('Undefined reference ' . $name);   
+        }
         $reference = $this->references[$name];
         $meta = $this->manager->getClassMetadata(get_class($reference));
         $uow = $this->manager->getUnitOfWork();

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -144,7 +144,7 @@ class ReferenceRepository
      */
     public function getReference($name)
     {
-        if (empty($this->references[$name])) {
+        if (!$this->hasReference($name)) {
             throw new \InvalidArgumentException('Undefined reference ' . $name);   
         }
 

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -139,12 +139,15 @@ class ReferenceRepository
      *
      * @param string $name
      * @return object
+     *
+     * @throws \InvalidArgumentException If reference name can't be found.
      */
     public function getReference($name)
     {
         if (empty($this->references[$name])) {
-            throw new \Exception('Undefined reference ' . $name);   
+            throw new \InvalidArgumentException('Undefined reference ' . $name);   
         }
+
         $reference = $this->references[$name];
         $meta = $this->manager->getClassMetadata(get_class($reference));
         $uow = $this->manager->getUnitOfWork();


### PR DESCRIPTION
On doctrine:fixtures:load if data-fixtures cannot get a reference will fail with a undefined index.

I think this can be improve, to really pass the message undefined reference.

So I improved from this:
[ErrorException]
Notice: Undefined index: database_1_1 in /home/www/eb/platform/vendor/doctrine/data-fixtures/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php line 145

To:
[Exception]
Undefined reference database_1_1