### PR TITLE
PHPCRPurger: Updated call to deprecated deleteAllNodes()

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/PHPCRPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/PHPCRPurger.php
@@ -72,7 +72,7 @@ class PHPCRPurger implements PurgerInterface
     public function purge()
     {
         $session = $this->dm->getPhpcrSession();
-        NodeHelper::deleteAllNodes($session);
+        NodeHelper::purgeWorkspace($session);
         $session->save();
     }
 }


### PR DESCRIPTION
A very small thing, but I kept noticing this. ;)

In `PHPCR\Util\NodeHelper`, `deleteAllNodes()` has been deprecated in favour of (and calls) `purgeWorkspace()`.
