### PR TITLE
Wrong class/interface name

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
@@ -61,7 +61,7 @@ abstract class AbstractExecutor
     /**
      * Sets the Purger instance to use for this executor instance.
      *
-     * @param Purger $purger
+     * @param PurgerInterface $purger
      */
     public function setPurger(PurgerInterface $purger)
     {


### PR DESCRIPTION
There is no class or interface Doctrine\Common\DataFixtures\Executor\Purger. This pull request should fix some fatal errors.

Problems was found during mocking (using Mockery):

```
1) Scribol\Coin2\TestBundle\Tests\Fixtures\LoaderTest::testFile
ReflectionException: Class Doctrine\Common\DataFixtures\Executor\Purger does not exist
```
