### PR TITLE
Updated incorrect PhpDoc

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -31,7 +31,7 @@ interface FixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      *
-     * @param Doctrine\Common\Persistence\ObjectManager $manager
+     * @param ObjectManager $manager
      */
     function load(ObjectManager $manager);
 }


### PR DESCRIPTION
PhpStorm shows an error. I think it's because ObjectManager was already imported.
