### PR TITLE
Fixing failing test cases and Loader issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+before_script:
+  - composer selfupdate
+  - composer install --prefer-dist --dev
+
+script: phpunit --colors --coverage-text

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,14 @@
 >
     <testsuites>
         <testsuite name="Doctrine Data Fixtures Test Suite">
-            <directory>./tests/Doctrine/</directory>
+            <directory suffix="Test.php">./tests/Doctrine/</directory>
         </testsuite>
     </testsuites>
+
+    <!-- Coverage filter -->
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./lib</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
@@ -96,7 +96,7 @@ class DependentFixtureTest extends BaseTest
 
 
     /**
-     * @expectedException Doctrine\Common\DataFixtures\Exception\CircularReferenceException
+     * @expectedException \Doctrine\Common\DataFixtures\Exception\CircularReferenceException
      */
     public function test_orderFixturesByDependencies_circularReferencesMakeMethodThrowCircularReferenceException()
     {
@@ -110,7 +110,7 @@ class DependentFixtureTest extends BaseTest
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function test_orderFixturesByDependencies_fixturesCantHaveItselfAsParent()
     {
@@ -145,7 +145,7 @@ class DependentFixtureTest extends BaseTest
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function test_inCaseAFixtureHasAnUnexistentDependencyOrIfItWasntLoaded_throwsException()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,5 +18,5 @@
  * <http://www.doctrine-project.org>.
  */
 
-$loader = require_once __DIR__ . "/../vendor/autoload.php";
+$loader = require __DIR__ . "/../vendor/autoload.php";
 $loader->add('Doctrine\\Tests\\', __DIR__);


### PR DESCRIPTION
Since I wanted to start developing on some feature, I was trying
to run the test suite which was impossible due to some autoload issues
as well as some programatic issues which were causing infinite
recursion in the DependentFixtureTest and Fatal Errors.

- [x] Adding 'Test.php' suffix to phpunit.xml.dist
- [x] Use require over require_once in tests/bootstrap.php
- [x] Fixing Loader to check for dependency class existance to not produce fatal error
- [x] Checking for parent and child class before adding dependency
- [x] Using namespaces starting from root in annotations for better IDE compatibility
- [ ] Fix ProxyReferenceRepositoryTest
- [x] Enable travis CI | Enable Scrutinizer CI

This eliminates the issues with testing described here:
https://github.com/doctrine/data-fixtures/pull/90
