### PR TITLE
Fix truncate on MySQL >= 5.5

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -63,11 +63,14 @@ abstract class AbstractFixture implements SharedFixtureInterface
     /**
      * Set the reference entry identified by $name
      * and referenced to managed $object. If $name
-     * already is set, it overrides it
+     * already is set, it throws a 
+     * BadMethodCallException exception
      * 
      * @param string $name
      * @param object $object - managed object
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::addReference
+     * @throws BadMethodCallException - if repository already has
+     *      a reference by $name
      * @return void
      */
     public function addReference($name, $object)

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -33,5 +33,5 @@ interface FixtureInterface
      *
      * @param ObjectManager $manager
      */
-    function load(ObjectManager $manager);
+    public function load(ObjectManager $manager);
 }

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -31,7 +31,7 @@ interface FixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      *
-     * @param Doctrine\Common\Persistence\ObjectManager $manager
+     * @param ObjectManager $manager
      */
     function load(ObjectManager $manager);
 }

--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -28,6 +28,7 @@ use Doctrine\Common\Util\ClassUtils;
  * Allow data fixture references and identities to be persisted when cached data fixtures
  * are pre-loaded, for example, by LiipFunctionalTestBundle\Test\WebTestCase loadFixtures().
  *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Anthon Pang <anthonp@nationalfibre.net>
  */
 class ProxyReferenceRepository extends ReferenceRepository
@@ -59,12 +60,13 @@ class ProxyReferenceRepository extends ReferenceRepository
      */
     public function serialize()
     {
+        $unitOfWork       = $this->getManager()->getUnitOfWork();
         $simpleReferences = array();
 
         foreach ($this->getReferences() as $name => $reference) {
             $className = $this->getRealClass(get_class($reference));
 
-            $simpleReferences[$name] = array($className, $reference->getId());
+            $simpleReferences[$name] = array($className, $this->getIdentifier($reference, $unitOfWork));
         }
 
         $serializedData = json_encode(array(
@@ -90,7 +92,7 @@ class ProxyReferenceRepository extends ReferenceRepository
                 $name,
                 $this->getManager()->getReference(
                     $proxyReference[0], // entity class name
-                    $proxyReference[1]  // id
+                    $proxyReference[1]  // identifiers
                 )
             );
         }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Common\DataFixtures\Purger;
 
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Internal\CommitOrderCalculator;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -127,12 +128,20 @@ class ORMPurger implements PurgerInterface
             $orderedTables[] = $class->getQuotedTableName($platform);
         }
 
+        if ($platform instanceof MySqlPlatform) {
+            $this->setForeignKeyChecks(false);
+        }
+
         foreach($orderedTables as $tbl) {
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                 $this->em->getConnection()->executeUpdate("DELETE FROM " . $tbl);
             } else {
                 $this->em->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }
+        }
+
+        if ($platform instanceof MySqlPlatform) {
+            $this->setForeignKeyChecks(true);
         }
     }
 
@@ -195,5 +204,19 @@ class ORMPurger implements PurgerInterface
         }
 
         return $associationTables;
+    }
+
+    /**
+     * Enable/disable foreign key checks on the MySQL platform
+     *
+     * @param bool $bool
+     */
+    private function setForeignKeyChecks($bool)
+    {
+        if ($this->purgeMode !== self::PURGE_MODE_TRUNCATE) {
+            return;
+        }
+
+        $this->em->getConnection()->query(sprintf('SET FOREIGN_KEY_CHECKS=%s', (int) $bool));
     }
 }

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -70,14 +70,23 @@ class ReferenceRepository
      * @param object $reference Reference object
      * @param object $uow       Unit of work
      *
-     * @return mixed
+     * @return array
      */
     protected function getIdentifier($reference, $uow)
     {
+        // In case Reference is not yet managed in UnitOfWork
+        if ( ! $uow->isInIdentityMap($reference)) {
+            $class = $this->manager->getClassMetadata(get_class($reference));
+
+            return $class->getIdentifierValues($reference);
+        }
+
+        // Dealing with ORM UnitOfWork
         if (method_exists($uow, 'getEntityIdentifier')) {
             return $uow->getEntityIdentifier($reference);
         }
 
+        // ODM UnitOfWork
         return $uow->getDocumentIdentifier($reference);
     }
 


### PR DESCRIPTION
When loading fixtures with purge mode truncate (`--purge-with-truncate` in the bundle's command) on MySQL >= 5.5, an error is thrown:

``` mysql
SQLSTATE[42000]: Syntax error or access violation: 
1701 Cannot truncate a table referenced in a foreign key constraint ...
```

It turns out that with MySQL 5.5, the `TRUNCATE` behaviour has changed. From the [MySQL docs](http://dev.mysql.com/doc/refman/5.5/en/truncate-table.html):

> TRUNCATE TABLE fails for an InnoDB table if there are any FOREIGN KEY constraints from other tables that reference the table. Foreign key constraints between columns of the same table are permitted.

With this PR foreign key checks are disabled before starting the purge, and re-enabled after, so purge made truncate works again. Fixes #113, #17.
