### PR TITLE
Allow dependent fixtures to reference other types of fixture without triggering an error.

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -63,11 +63,14 @@ abstract class AbstractFixture implements SharedFixtureInterface
     /**
      * Set the reference entry identified by $name
      * and referenced to managed $object. If $name
-     * already is set, it overrides it
+     * already is set, it throws a 
+     * BadMethodCallException exception
      * 
      * @param string $name
      * @param object $object - managed object
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::addReference
+     * @throws BadMethodCallException - if repository already has
+     *      a reference by $name
      * @return void
      */
     public function addReference($name, $object)

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -33,5 +33,5 @@ interface FixtureInterface
      *
      * @param ObjectManager $manager
      */
-    function load(ObjectManager $manager);
+    public function load(ObjectManager $manager);
 }

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -31,7 +31,7 @@ interface FixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      *
-     * @param Doctrine\Common\Persistence\ObjectManager $manager
+     * @param ObjectManager $manager
      */
     function load(ObjectManager $manager);
 }

--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -327,7 +327,7 @@ class Loader
         }
 
         foreach ($classes as $class) {
-            if ($sequences[$class] === -1) {
+            if (array_key_exists($class, $sequences) && ($sequences[$class] === -1)) {
                 $unsequencedClasses[] = $class;
             }
         }

--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -28,6 +28,7 @@ use Doctrine\Common\Util\ClassUtils;
  * Allow data fixture references and identities to be persisted when cached data fixtures
  * are pre-loaded, for example, by LiipFunctionalTestBundle\Test\WebTestCase loadFixtures().
  *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Anthon Pang <anthonp@nationalfibre.net>
  */
 class ProxyReferenceRepository extends ReferenceRepository
@@ -59,12 +60,13 @@ class ProxyReferenceRepository extends ReferenceRepository
      */
     public function serialize()
     {
+        $unitOfWork       = $this->getManager()->getUnitOfWork();
         $simpleReferences = array();
 
         foreach ($this->getReferences() as $name => $reference) {
             $className = $this->getRealClass(get_class($reference));
 
-            $simpleReferences[$name] = array($className, $reference->getId());
+            $simpleReferences[$name] = array($className, $this->getIdentifier($reference, $unitOfWork));
         }
 
         $serializedData = json_encode(array(
@@ -90,7 +92,7 @@ class ProxyReferenceRepository extends ReferenceRepository
                 $name,
                 $this->getManager()->getReference(
                     $proxyReference[0], // entity class name
-                    $proxyReference[1]  // id
+                    $proxyReference[1]  // identifiers
                 )
             );
         }

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -70,14 +70,23 @@ class ReferenceRepository
      * @param object $reference Reference object
      * @param object $uow       Unit of work
      *
-     * @return mixed
+     * @return array
      */
     protected function getIdentifier($reference, $uow)
     {
+        // In case Reference is not yet managed in UnitOfWork
+        if ( ! $uow->isInIdentityMap($reference)) {
+            $class = $this->manager->getClassMetadata(get_class($reference));
+
+            return $class->getIdentifierValues($reference);
+        }
+
+        // Dealing with ORM UnitOfWork
         if (method_exists($uow, 'getEntityIdentifier')) {
             return $uow->getEntityIdentifier($reference);
         }
 
+        // ODM UnitOfWork
         return $uow->getDocumentIdentifier($reference);
     }
 


### PR DESCRIPTION
When mixing ordered and dependent fixtures, if a dependent fixture references an ordered fixture in getDependencies it triggers an error during loading. This is because the ordered fixtures are not included in the list of classes that need to be sequenced, triggering a Notice error when using the class name as an array index.

This  fix checks to see if the class name exists in the array before checking if it has been sequenced already.
