### PR TITLE
Update bootstrap.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
   allow_failures:
     - php: hhvm
 
-before_script: composer --dev --prefer-source install
+before_script:
+    - composer self-update
+    - composer --dev --prefer-source install
 
 script: phpunit -v

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "autoload-dev": {
         "psr-0": { "Doctrine\\Tests": "tests/" }
-    }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     "autoload": {
         "psr-0": { "Doctrine\\Common\\DataFixtures": "lib/" }
     },
+    "autoload-dev": {
+        "psr-0": { "Doctrine\\Tests": "tests/" }
+    }
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,5 +18,5 @@
  * <http://www.doctrine-project.org>.
  */
 
-$loader = require_once __DIR__ . "/../vendor/autoload.php";
+$loader = require __DIR__ . "/../vendor/autoload.php";
 $loader->add('Doctrine\\Tests\\', __DIR__);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,5 +18,4 @@
  * <http://www.doctrine-project.org>.
  */
 
-$loader = require __DIR__ . "/../vendor/autoload.php";
-$loader->add('Doctrine\\Tests\\', __DIR__);
+require_once __DIR__ . "/../vendor/autoload.php";


### PR DESCRIPTION
Composer does not give back `$loader` object when using `require_once` (returns `true` instead). Use require to get object.

The testing bootstrap does not support being started from within the vendor folder. Only run from the `src` folder is supported. The bootstrap could be more adaptive like this https://github.com/doctrine/doctrine2/blob/master/tests/Doctrine/Tests/TestInit.php

(overall i noticed the testing bootstrap is inconsistent throughout doctrine libraries)