### PR TITLE
Fill simpleReferences with IDs using identities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
+before_script: composer --dev --prefer-source install
+
+script: ./vendor/bin/phpunit -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ matrix:
 
 before_script: composer --dev --prefer-source install
 
-script: ./vendor/bin/phpunit -v
+script: phpunit -v

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.2,<2.5-dev"
+        "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "doctrine/orm": ">=2.2,<2.5-dev"
+        "doctrine/orm": "~2.2"
     },
     "suggest": {
         "doctrine/orm": "For loading ORM fixtures",

--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -63,11 +63,14 @@ abstract class AbstractFixture implements SharedFixtureInterface
     /**
      * Set the reference entry identified by $name
      * and referenced to managed $object. If $name
-     * already is set, it overrides it
+     * already is set, it throws a 
+     * BadMethodCallException exception
      * 
      * @param string $name
      * @param object $object - managed object
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::addReference
+     * @throws BadMethodCallException - if repository already has
+     *      a reference by $name
      * @return void
      */
     public function addReference($name, $object)

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -33,5 +33,5 @@ interface FixtureInterface
      *
      * @param ObjectManager $manager
      */
-    function load(ObjectManager $manager);
+    public function load(ObjectManager $manager);
 }

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -31,7 +31,7 @@ interface FixtureInterface
     /**
      * Load data fixtures with the passed EntityManager
      *
-     * @param Doctrine\Common\Persistence\ObjectManager $manager
+     * @param ObjectManager $manager
      */
     function load(ObjectManager $manager);
 }

--- a/lib/Doctrine/Common/DataFixtures/OrderedFixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/OrderedFixtureInterface.php
@@ -34,5 +34,5 @@ interface OrderedFixtureInterface
      * 
      * @return integer
      */  
-    function getOrder();
+    public function getOrder();
 }

--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -28,6 +28,7 @@ use Doctrine\Common\Util\ClassUtils;
  * Allow data fixture references and identities to be persisted when cached data fixtures
  * are pre-loaded, for example, by LiipFunctionalTestBundle\Test\WebTestCase loadFixtures().
  *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author Anthon Pang <anthonp@nationalfibre.net>
  */
 class ProxyReferenceRepository extends ReferenceRepository
@@ -59,12 +60,13 @@ class ProxyReferenceRepository extends ReferenceRepository
      */
     public function serialize()
     {
+        $unitOfWork       = $this->getManager()->getUnitOfWork();
         $simpleReferences = array();
 
         foreach ($this->getReferences() as $name => $reference) {
             $className = $this->getRealClass(get_class($reference));
 
-            $simpleReferences[$name] = array($className, $reference->getId());
+            $simpleReferences[$name] = array($className, $this->getIdentifier($reference, $unitOfWork));
         }
 
         $serializedData = json_encode(array(
@@ -90,7 +92,7 @@ class ProxyReferenceRepository extends ReferenceRepository
                 $name,
                 $this->getManager()->getReference(
                     $proxyReference[0], // entity class name
-                    $proxyReference[1]  // id
+                    $proxyReference[1]  // identifiers
                 )
             );
         }

--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -63,15 +63,15 @@ class ProxyReferenceRepository extends ReferenceRepository
         $unitOfWork       = $this->getManager()->getUnitOfWork();
         $simpleReferences = array();
 
+        $identities = $this->getIdentities();
         foreach ($this->getReferences() as $name => $reference) {
             $className = $this->getRealClass(get_class($reference));
 
-            $simpleReferences[$name] = array($className, $this->getIdentifier($reference, $unitOfWork));
+            $simpleReferences[$name] = array($className, $identities[$name]);
         }
-
         $serializedData = json_encode(array(
             'references' => $simpleReferences,
-            'identities' => $this->getIdentities(),
+            'identities' => $identities,
         ));
 
         return $serializedData;

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -122,7 +122,7 @@ class ORMPurger implements PurgerInterface
             if (
                 ($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName) ||
                 (isset($class->isEmbeddedClass) && $class->isEmbeddedClass) ||
-                 $class->isMappedSuperclass
+                $class->isMappedSuperclass
             ) {
                 continue;
             }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -119,8 +119,11 @@ class ORMPurger implements PurgerInterface
         for ($i = count($commitOrder) - 1; $i >= 0; --$i) {
             $class = $commitOrder[$i];
 
-            if (($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName)
-                || $class->isMappedSuperclass || $class->isEmbeddedClass) {
+            if (
+                ($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName) ||
+                (isset($class->isEmbeddedClass) && $class->isEmbeddedClass) ||
+                 $class->isMappedSuperclass
+            ) {
                 continue;
             }
 

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -120,7 +120,7 @@ class ORMPurger implements PurgerInterface
             $class = $commitOrder[$i];
 
             if (($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName)
-                || $class->isMappedSuperclass) {
+                || $class->isMappedSuperclass || $class->isEmbeddedClass) {
                 continue;
             }
 

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -70,14 +70,23 @@ class ReferenceRepository
      * @param object $reference Reference object
      * @param object $uow       Unit of work
      *
-     * @return mixed
+     * @return array
      */
     protected function getIdentifier($reference, $uow)
     {
+        // In case Reference is not yet managed in UnitOfWork
+        if ( ! $uow->isInIdentityMap($reference)) {
+            $class = $this->manager->getClassMetadata(get_class($reference));
+
+            return $class->getIdentifierValues($reference);
+        }
+
+        // Dealing with ORM UnitOfWork
         if (method_exists($uow, 'getEntityIdentifier')) {
             return $uow->getEntityIdentifier($reference);
         }
 
+        // ODM UnitOfWork
         return $uow->getDocumentIdentifier($reference);
     }
 


### PR DESCRIPTION
The $simpleReferences don't containt the array with the IDs in some cases but they are in the identities. Then we can use the identities to fill the $simpleReferences.
