### PR TITLE
add a getter method to ORMPurger for retrieving all metadata

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -99,7 +99,7 @@ class ORMPurger implements PurgerInterface
     public function purge()
     {
         $classes = array();
-        $metadatas = $this->em->getMetadataFactory()->getAllMetadata();
+        $metadatas = $this->getAllMetadata();
 
         foreach ($metadatas as $metadata) {
             if ( ! $metadata->isMappedSuperclass) {
@@ -137,6 +137,16 @@ class ORMPurger implements PurgerInterface
                 $this->em->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }
         }
+    }
+
+    /**
+     * Retrieve an array of all the metadata the EntityManager knows about
+     *
+     * @return array
+     */
+    protected function getAllMetadata()
+    {
+        return $this->em->getMetadataFactory()->getAllMetadata();
     }
 
     private function getCommitOrder(EntityManager $em, array $classes)


### PR DESCRIPTION
The motivation behind this PR is to allow for an overriding class to get in the middle of getAllMetadata() and optionally remove any tables which should not be purged when fixtures are run. It does not cause any BC breaks.

See https://github.com/kayue/KayueWordpressBundle/pull/37 for an example of a real-world use case.
