### PR TITLE
Removed redundant namespace

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -19,7 +19,6 @@
 
 namespace Doctrine\Common\DataFixtures;
 
-use Doctrine\ORM\EntityManager;
 use Doctrine\Common\DataFixtures\Exception\CircularReferenceException;
 
 /**


### PR DESCRIPTION
Note: Travis is failing on [Loader.php nesting](https://travis-ci.org/doctrine/data-fixtures/jobs/32806493#L68), probably not due to this PR.
