### PR TITLE
Use EntityManagerInterface instead of EntityManager (to support decorators, etc)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "doctrine/orm": "~2.2"
+        "doctrine/orm": "~2.4"
     },
     "suggest": {
         "doctrine/orm": "For loading ORM fixtures",

--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\Common\DataFixtures\Executor;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener;
 use Doctrine\Common\DataFixtures\ReferenceRepository;
@@ -34,9 +34,9 @@ class ORMExecutor extends AbstractExecutor
     /**
      * Construct new fixtures loader instance.
      *
-     * @param EntityManager $em EntityManager instance used for persistence.
+     * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
      */
-    public function __construct(EntityManager $em, ORMPurger $purger = null)
+    public function __construct(EntityManagerInterface $em, ORMPurger $purger = null)
     {
         $this->em = $em;
         if ($purger !== null) {
@@ -49,9 +49,9 @@ class ORMExecutor extends AbstractExecutor
     }
 
     /**
-     * Retrieve the EntityManager instance this executor instance is using.
+     * Retrieve the EntityManagerInterface instance this executor instance is using.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getObjectManager()
     {
@@ -75,7 +75,7 @@ class ORMExecutor extends AbstractExecutor
     public function execute(array $fixtures, $append = false)
     {
         $executor = $this;
-        $this->em->transactional(function(EntityManager $em) use ($executor, $fixtures, $append) {
+        $this->em->transactional(function(EntityManagerInterface $em) use ($executor, $fixtures, $append) {
             if ($append === false) {
                 $executor->purge();
             }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\Common\DataFixtures\Purger;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\CommitOrderCalculator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
@@ -34,7 +34,7 @@ class ORMPurger implements PurgerInterface
     const PURGE_MODE_DELETE = 1;
     const PURGE_MODE_TRUNCATE = 2;
 
-    /** EntityManager instance used for persistence. */
+    /** EntityManagerInterface instance used for persistence. */
     private $em;
 
     /**
@@ -47,9 +47,9 @@ class ORMPurger implements PurgerInterface
     /**
      * Construct new purger instance.
      *
-     * @param EntityManager $em EntityManager instance used for persistence.
+     * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
      */
-    public function __construct(EntityManager $em = null)
+    public function __construct(EntityManagerInterface $em = null)
     {
         $this->em = $em;
     }
@@ -76,19 +76,19 @@ class ORMPurger implements PurgerInterface
     }
 
     /**
-     * Set the EntityManager instance this purger instance should use.
+     * Set the EntityManagerInterface instance this purger instance should use.
      *
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      */
-    public function setEntityManager(EntityManager $em)
+    public function setEntityManager(EntityManagerInterface $em)
     {
       $this->em = $em;
     }
 
     /**
-     * Retrieve the EntityManager instance this purger instance is using.
+     * Retrieve the EntityManagerInterface instance this purger instance is using.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getObjectManager()
     {
@@ -139,7 +139,7 @@ class ORMPurger implements PurgerInterface
         }
     }
 
-    private function getCommitOrder(EntityManager $em, array $classes)
+    private function getCommitOrder(EntityManagerInterface $em, array $classes)
     {
         $calc = new CommitOrderCalculator;
 


### PR DESCRIPTION
If you use [EntityManagerDecorator](http://www.doctrine-project.org/api/orm/2.4/class-Doctrine.ORM.Decorator.EntityManagerDecorator.html) or any other entity manager that isn't a Doctrine\ORM\EntityManager class or subclass, then the fixtures break.  Instead, it should use EntityManagerInterface.