### PR TITLE
Fixed circular dependencies detection

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -125,16 +125,20 @@ class Loader
                     get_class($fixture),
                     'OrderedFixtureInterface',
                     'DependentFixtureInterface'));
-            } elseif ($fixture instanceof OrderedFixtureInterface) {
+            }
+
+            $this->fixtures[$fixtureClass] = $fixture;
+
+            if ($fixture instanceof OrderedFixtureInterface) {
                 $this->orderFixturesByNumber = true;
             } elseif ($fixture instanceof DependentFixtureInterface) {
                 $this->orderFixturesByDependencies = true;
                 foreach($fixture->getDependencies() as $class) {
-                    $this->addFixture(new $class);
+                    if (class_exists($class)) {
+                        $this->addFixture(new $class);
+                    }
                 }
             }
-
-            $this->fixtures[$fixtureClass] = $fixture;
         }
     }
 


### PR DESCRIPTION
Fixes #142
Bug introduced in #84

 1. The fixture is now registered in the array _before_ recursing.
 2. `class_exists` is now called so that the error about unexistant
    dependencies is properly thrown in `validateDependencies`.