### PR TITLE
Fixed test for instanceof Doctrine\ORM\Proxy\Proxy

### DIFF
--- a/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
@@ -113,7 +113,9 @@ class ProxyReferenceRepositoryTest extends BaseTest
 
         $ref = $proxyReferenceRepository->getReference('admin-role');
 
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $ref);
+        // before clearing, the reference is not yet a proxy
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $ref);
+        $this->assertInstanceOf('Doctrine\Tests\Common\DataFixtures\TestEntity\Role', $ref);
 
         // now test reference reconstruction from identity
         $em->clear();


### PR DESCRIPTION
As @stof said:
Getting the reference before the EntityManager is cleared will not
return a proxy instance as the manager already contains a managed
instance.

This test always failed, even where it was first introduced: 5bc3727

Fixes a task in #116