### PR TITLE
Don't purge readonly Entities

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -123,7 +123,8 @@ class ORMPurger implements PurgerInterface
             if (
                 ($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName) ||
                 (isset($class->isEmbeddedClass) && $class->isEmbeddedClass) ||
-                $class->isMappedSuperclass
+                $class->isMappedSuperclass ||
+                $class->isReadOnly
             ) {
                 continue;
             }


### PR DESCRIPTION
The ORMPurger currently tries to truncate database views (which obviously fails), even though the entity is marked as "readonly" using following ORM annotation:
```php
/**
 * @ORM\Entity(readOnly=true)
 * @ORM\Table(name="foo")
 */
```

This commit skips readonly entities in ORMPurger.