### PR TITLE
Revert "Use EntityManagerInterface instead of EntityManager"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "doctrine/orm": "~2.4"
+        "doctrine/orm": "~2.2"
     },
     "suggest": {
         "doctrine/orm": "For loading ORM fixtures",

--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\Common\DataFixtures\Executor;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityManager;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener;
 use Doctrine\Common\DataFixtures\ReferenceRepository;
@@ -34,9 +34,9 @@ class ORMExecutor extends AbstractExecutor
     /**
      * Construct new fixtures loader instance.
      *
-     * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
+     * @param EntityManager $em EntityManager instance used for persistence.
      */
-    public function __construct(EntityManagerInterface $em, ORMPurger $purger = null)
+    public function __construct(EntityManager $em, ORMPurger $purger = null)
     {
         $this->em = $em;
         if ($purger !== null) {
@@ -49,9 +49,9 @@ class ORMExecutor extends AbstractExecutor
     }
 
     /**
-     * Retrieve the EntityManagerInterface instance this executor instance is using.
+     * Retrieve the EntityManager instance this executor instance is using.
      *
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getObjectManager()
     {
@@ -75,7 +75,7 @@ class ORMExecutor extends AbstractExecutor
     public function execute(array $fixtures, $append = false)
     {
         $executor = $this;
-        $this->em->transactional(function(EntityManagerInterface $em) use ($executor, $fixtures, $append) {
+        $this->em->transactional(function(EntityManager $em) use ($executor, $fixtures, $append) {
             if ($append === false) {
                 $executor->purge();
             }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\Common\DataFixtures\Purger;
 
-use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Internal\CommitOrderCalculator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -35,7 +35,7 @@ class ORMPurger implements PurgerInterface
     const PURGE_MODE_DELETE = 1;
     const PURGE_MODE_TRUNCATE = 2;
 
-    /** EntityManagerInterface instance used for persistence. */
+    /** EntityManager instance used for persistence. */
     private $em;
 
     /**
@@ -48,9 +48,9 @@ class ORMPurger implements PurgerInterface
     /**
      * Construct new purger instance.
      *
-     * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
+     * @param EntityManager $em EntityManager instance used for persistence.
      */
-    public function __construct(EntityManagerInterface $em = null)
+    public function __construct(EntityManager $em = null)
     {
         $this->em = $em;
     }
@@ -77,19 +77,19 @@ class ORMPurger implements PurgerInterface
     }
 
     /**
-     * Set the EntityManagerInterface instance this purger instance should use.
+     * Set the EntityManager instance this purger instance should use.
      *
-     * @param EntityManagerInterface $em
+     * @param EntityManager $em
      */
-    public function setEntityManager(EntityManagerInterface $em)
+    public function setEntityManager(EntityManager $em)
     {
       $this->em = $em;
     }
 
     /**
-     * Retrieve the EntityManagerInterface instance this purger instance is using.
+     * Retrieve the EntityManager instance this purger instance is using.
      *
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getObjectManager()
     {
@@ -137,7 +137,7 @@ class ORMPurger implements PurgerInterface
         }
     }
 
-    private function getCommitOrder(EntityManagerInterface $em, array $classes)
+    private function getCommitOrder(EntityManager $em, array $classes)
     {
         $calc = new CommitOrderCalculator;
 


### PR DESCRIPTION
Fixes #183, #185

Reverts #166, it is causing the BC break, it will be added to `v1.1` instead.

Revert "Use EntityManagerInterface instead of EntityManager (to support decorators, etc)"
Revert "Upgrade doctrine/orm to ~2.4"
This reverts commit 0c96db584a4ccb7cfa4f68d8ee435a3a6f387e81.
This reverts commit 48ec2812ab8d3c044f975b69a0e834c59b0a4a57.