### PR TITLE
Added a conflict on doctrim/orm < 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "require-dev": {
         "doctrine/orm": "~2.4"
     },
+    "conflict": {
+        "doctrine/orm": "< 2.4"
+    },
     "suggest": {
         "doctrine/orm": "For loading ORM fixtures",
         "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",


### PR DESCRIPTION
`EntityManagerInterface` is only available in 2.4. Since we do not hard depend on `doctrine/orm`, add it as conflict instead.

Related to #166 #183 #186