### PR TITLE
Changed the MongoDBPurger class to only clear collections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ php:
   - 5.6
   - hhvm
 
-install: composer install
+services: mongodb
+
+before_install:
+    - "[ $TRAVIS_PHP_VERSION = 'hhvm' ] || echo 'extension = mongo.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini"
+
+install: 
+    - composer install --dev
+    - "[ $TRAVIS_PHP_VERSION = 'hhvm' ] || composer require 'doctrine/mongodb-odm' '*@beta'"
 
 script: phpunit -v

--- a/lib/Doctrine/Common/DataFixtures/Purger/MongoDBPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/MongoDBPurger.php
@@ -70,5 +70,6 @@ class MongoDBPurger implements PurgerInterface
                 $this->dm->getDocumentCollection($metadata->name)->drop();
             }
         }
+        $this->dm->getSchemaManager()->ensureIndexes();
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace Doctrine\Tests\Common\DataFixtures\Purger;
+
+use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
+use Doctrine\Tests\Common\DataFixtures\BaseTest;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\Tests\Common\DataFixtures\TestDocument\Role;
+
+class MongoDBPurgerTest extends BaseTest
+{
+    const TEST_DOCUMENT_ROLE = 'Doctrine\Tests\Common\DataFixtures\TestDocument\Role';
+
+    private function getDocumentManager()
+    {
+        if (!class_exists('Doctrine\ODM\MongoDB\DocumentManager')) {
+            $this->markTestSkipped('Missing doctrine/mongodb-odm');
+        }
+
+        $root = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
+
+        $config = new Configuration();
+        $config->setProxyDir($root . '/generate/proxies');
+        $config->setProxyNamespace('Proxies');
+        $config->setHydratorDir($root . '/generate/hydrators');
+        $config->setHydratorNamespace('Hydrators');
+        $config->setMetadataDriverImpl(AnnotationDriver::create(dirname(__DIR__) . '/TestDocument'));
+        AnnotationDriver::registerAnnotationClasses();
+
+        $dm = DocumentManager::create(null, $config);
+        if (!$dm->getConnection()->connect()) {
+            $this->markTestSkipped('Unable to connect to MongoDB');
+        }
+
+        return $dm;
+    }
+
+    private function getPurger()
+    {
+        return new MongoDBPurger($this->getDocumentManager());
+    }
+
+    public function testPurgeKeepsIndices()
+    {
+        $purger = $this->getPurger();
+        $dm = $purger->getObjectManager();
+
+        $collection = $dm->getDocumentCollection(self::TEST_DOCUMENT_ROLE);
+        $collection->drop();
+
+        $this->assertCount(0, $collection->getIndexInfo());
+
+        $role = new Role;
+        $role->setName('role');
+        $dm->persist($role);
+        $dm->flush();
+
+        $schema = $dm->getSchemaManager()->ensureDocumentIndexes(self::TEST_DOCUMENT_ROLE);
+        $this->assertCount(2, $collection->getIndexInfo());
+
+        $purger->purge();
+        $this->assertCount(2, $collection->getIndexInfo());
+    }
+}

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestDocument/Role.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestDocument/Role.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures\TestDocument;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class Role
+{
+    /**
+     * @ODM\Id
+     */
+    private $id;
+
+    /**
+     * @ODM\String
+     * @ODM\Index
+     */
+    private $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
Changed the MongoDBPurger class to only clear collections, not remove them.

Instead of dropping all collections, we should remove all documents in a
collection instead. This avoids problems where indexes are lost while dropping
the collection, and collections not being recreated (with a schema create tool)
while loading fixtures.

Fixes #150
Superseeds #118 from @gerryvdm