### PR TITLE
handle older versions of phpcr-odm

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
@@ -60,7 +60,7 @@ class PHPCRExecutor extends AbstractExecutor
     {
         $that = $this;
 
-        $this->dm->transactional(function ($dm) use ($append, $that, $fixtures) {
+        $function = function ($dm) use ($append, $that, $fixtures) {
             if ($append === false) {
                 $that->purge();
             }
@@ -68,7 +68,13 @@ class PHPCRExecutor extends AbstractExecutor
             foreach ($fixtures as $fixture) {
                 $that->load($dm, $fixture);
             }
-        });
+        };
+
+        if (method_exists($this->dm, 'transactional')) {
+            $this->dm->transactional($function);
+        } else {
+            $function($this->dm);
+        }
     }
 }
 


### PR DESCRIPTION
phpcr-odm only got transactional added in a recent version. we get  https://github.com/symfony-cmf/symfony-cmf/issues/217

the alternative would be to declare a `conflicts` in composer.json to force using a version of phpcr-odm that has transactional.