### PR TITLE
fix DELETE sql query

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -131,11 +131,13 @@ class ORMPurger implements PurgerInterface
             $orderedTables[] = $class->getQuotedTableName($platform);
         }
 
+        $connection = $this->em->getConnection();
         foreach($orderedTables as $tbl) {
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-                $this->em->getConnection()->executeUpdate('DELETE FROM `' . $tbl . '`');
+                $tbl = $connection->quoteIdentifier($tbl);
+                $connection->executeUpdate('DELETE FROM ' . $tbl );
             } else {
-                $this->em->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+                $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }
         }
     }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -133,7 +133,7 @@ class ORMPurger implements PurgerInterface
 
         foreach($orderedTables as $tbl) {
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-                $this->em->getConnection()->executeUpdate("DELETE FROM " . $tbl);
+                $this->em->getConnection()->executeUpdate('DELETE FROM `' . $tbl . '`');
             } else {
                 $this->em->getConnection()->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }


### PR DESCRIPTION
Hello. 

Fix for sql error if table name is "order"

````sql                                                                                                                                                               
  An exception occurred while executing 'DELETE FROM order':                                                                                                                                                         
  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'order' at line 1  
```
