### PR TITLE
Demonstrate undefined index notice when using fixture dependent on ordered fixture.

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -48,7 +48,7 @@ class Loader
      * @var boolean
      */
     private $orderFixturesByNumber = false;
-    
+
     /**
      * Determines if we must order fixtures by its dependencies
      *
@@ -121,7 +121,7 @@ class Loader
 
         if (!isset($this->fixtures[$fixtureClass])) {
             if ($fixture instanceof OrderedFixtureInterface && $fixture instanceof DependentFixtureInterface) {
-                throw new \InvalidArgumentException(sprintf('Class "%s" can\'t implement "%s" and "%s" at the same time.', 
+                throw new \InvalidArgumentException(sprintf('Class "%s" can\'t implement "%s" and "%s" at the same time.',
                     get_class($fixture),
                     'OrderedFixtureInterface',
                     'DependentFixtureInterface'));
@@ -158,7 +158,7 @@ class Loader
         if ($this->orderFixturesByDependencies) {
             $this->orderFixturesByDependencies();
         }
-        
+
         if (!$this->orderFixturesByNumber && !$this->orderFixturesByDependencies) {
             $this->orderedFixtures = $this->fixtures;
         }
@@ -183,7 +183,7 @@ class Loader
 
     /**
      * Orders fixtures by number
-     * 
+     *
      * @todo maybe there is a better way to handle reordering
      * @return void
      */
@@ -204,22 +204,22 @@ class Loader
             return 0;
         });
     }
-    
-    
+
+
     /**
      * Orders fixtures by dependencies
-     * 
+     *
      * @return void
      */
     private function orderFixturesByDependencies()
     {
         $sequenceForClasses = array();
 
-        // If fixtures were already ordered by number then we need 
+        // If fixtures were already ordered by number then we need
         // to remove classes which are not instances of OrderedFixtureInterface
         // in case fixtures implementing DependentFixtureInterface exist.
         // This is because, in that case, the method orderFixturesByDependencies
-        // will handle all fixtures which are not instances of 
+        // will handle all fixtures which are not instances of
         // OrderedFixtureInterface
         if ($this->orderFixturesByNumber) {
             $count = count($this->orderedFixtures);
@@ -239,7 +239,7 @@ class Loader
                 continue;
             } elseif ($fixture instanceof DependentFixtureInterface) {
                 $dependenciesClasses = $fixture->getDependencies();
-                
+
                 $this->validateDependencies($dependenciesClasses);
 
                 if (!is_array($dependenciesClasses) || empty($dependenciesClasses)) {
@@ -249,7 +249,7 @@ class Loader
                 if (in_array($fixtureClass, $dependenciesClasses)) {
                     throw new \InvalidArgumentException(sprintf('Class "%s" can\'t have itself as a dependency', $fixtureClass));
                 }
-                
+
                 // We mark this class as unsequenced
                 $sequenceForClasses[$fixtureClass] = -1;
             } else {
@@ -261,7 +261,7 @@ class Loader
         // Now we order fixtures by sequence
         $sequence = 1;
         $lastCount = -1;
-        
+
         while (($count = count($unsequencedClasses = $this->getUnsequencedClasses($sequenceForClasses))) > 0 && $count !== $lastCount) {
             foreach ($unsequencedClasses as $key => $class) {
                 $fixture = $this->fixtures[$class];
@@ -270,29 +270,29 @@ class Loader
 
                 if (count($unsequencedDependencies) === 0) {
                     $sequenceForClasses[$class] = $sequence++;
-                }                
+                }
             }
-            
+
             $lastCount = $count;
         }
 
         $orderedFixtures = array();
-        
-        // If there're fixtures unsequenced left and they couldn't be sequenced, 
+
+        // If there're fixtures unsequenced left and they couldn't be sequenced,
         // it means we have a circular reference
         if ($count > 0) {
             $msg = 'Classes "%s" have produced a CircularReferenceException. ';
             $msg .= 'An example of this problem would be the following: Class C has class B as its dependency. ';
             $msg .= 'Then, class B has class A has its dependency. Finally, class A has class C as its dependency. ';
             $msg .= 'This case would produce a CircularReferenceException.';
-            
+
             throw new CircularReferenceException(sprintf($msg, implode(',', $unsequencedClasses)));
         } else {
             // We order the classes by sequence
             asort($sequenceForClasses);
 
             foreach ($sequenceForClasses as $class => $sequence) {
-                // If fixtures were ordered 
+                // If fixtures were ordered
                 $orderedFixtures[] = $this->fixtures[$class];
             }
         }
@@ -303,7 +303,7 @@ class Loader
     private function validateDependencies($dependenciesClasses)
     {
         $loadedFixtureClasses = array_keys($this->fixtures);
-        
+
         foreach ($dependenciesClasses as $class) {
             if (!in_array($class, $loadedFixtureClasses)) {
                 throw new \RuntimeException(sprintf('Fixture "%s" was declared as a dependency, but it should be added in fixture loader first.', $class));
@@ -322,6 +322,10 @@ class Loader
         }
 
         foreach ($classes as $class) {
+            if(!isset($sequences[$class])) {
+                dump('UNDEFINED INDEX');
+                die;
+            }
             if ($sequences[$class] === -1) {
                 $unsequencedClasses[] = $class;
             }

--- a/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Tests\Common\DataFixtures;
 
+use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -168,6 +169,14 @@ class DependentFixtureTest extends BaseTest
         $this->assertCount(2, $orderedFixtures);
         $this->assertInstanceOf(__NAMESPACE__ . '\BaseParentFixture1', array_shift($orderedFixtures));
         $this->assertInstanceOf(__NAMESPACE__ . '\DependentFixture1', array_shift($orderedFixtures));
+    }
+
+    public function test_UndefinedIndexWhenFixtureDependsOnOrderedFixture()
+    {
+        $loader = new Loader();
+        $loader->addFixture(new MyRole2Fixture());
+        $orderedFixtures = $loader->getFixtures();
+        $this->assertCount(2, $orderedFixtures);
     }
 }
 
@@ -393,4 +402,45 @@ class OrderedByNumberFixture3 implements FixtureInterface, OrderedFixtureInterfa
     {
         return 10;
     }
+}
+
+abstract class MyParentFixture extends AbstractFixture
+{
+    abstract protected function getFoo();
+
+    public function load(ObjectManager $manager)
+    {
+        $this->getFoo();
+    }
+
+}
+
+
+class MyRoleFixture extends MyParentFixture implements OrderedFixtureInterface
+{
+
+    protected function getFoo()
+    {
+    }
+
+    public function getOrder()
+    {
+        return 1;
+    }
+}
+
+class MyRole2Fixture extends MyParentFixture implements DependentFixtureInterface
+{
+
+    protected function getFoo()
+    {
+    }
+
+    function getDependencies()
+    {
+        return array(
+            'Doctrine\Tests\Common\DataFixtures\MyRoleFixture'
+        );
+    }
+
 }


### PR DESCRIPTION
This demonstrates that undefined index notice gets somehow suppressed during standalone tests. That notice stops execution when running doctrine:fixtures:load which is a problem. Sorry about the whitespace formatting, relevant change is at the end of Loader.php diff.
