### PR TITLE
Use UnitOfWork->contains() instead of isInIdentityMap when Phpcr document

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -20,6 +20,7 @@
 namespace Doctrine\Common\DataFixtures;
 
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\PHPCR\DocumentManager as PhpcrDocumentManager;
 
 /**
  * ReferenceRepository class manages references for
@@ -75,7 +76,7 @@ class ReferenceRepository
     protected function getIdentifier($reference, $uow)
     {
         // In case Reference is not yet managed in UnitOfWork
-        if ( ! $uow->isInIdentityMap($reference)) {
+        if ( ! $this->hasIdentifier($reference)) {
             $class = $this->manager->getClassMetadata(get_class($reference));
 
             return $class->getIdentifierValues($reference);
@@ -101,9 +102,10 @@ class ReferenceRepository
     public function setReference($name, $reference)
     {
         $this->references[$name] = $reference;
-        // in case if reference is set after flush, store its identity
-        $uow = $this->manager->getUnitOfWork();
-        if ($uow->isInIdentityMap($reference)) {
+
+        if ($this->hasIdentifier($reference)) {
+            // in case if reference is set after flush, store its identity
+            $uow = $this->manager->getUnitOfWork();
             $this->identities[$name] = $this->getIdentifier($reference, $uow);
         }
     }
@@ -158,14 +160,15 @@ class ReferenceRepository
 
         $reference = $this->references[$name];
         $meta = $this->manager->getClassMetadata(get_class($reference));
-        $uow = $this->manager->getUnitOfWork();
-        if (!$uow->isInIdentityMap($reference) && isset($this->identities[$name])) {
+
+        if (!$this->manager->contains($reference) && isset($this->identities[$name])) {
             $reference = $this->manager->getReference(
                 $meta->name,
                 $this->identities[$name]
             );
             $this->references[$name] = $reference; // already in identity map
         }
+
         return $reference;
     }
 
@@ -231,5 +234,24 @@ class ReferenceRepository
     public function getManager()
     {
         return $this->manager;
+    }
+
+    /**
+     * Checks if object has identifier already in unit of work.
+     *
+     * @param $reference
+     *
+     * @return bool
+     */
+    private function hasIdentifier($reference)
+    {
+        // in case if reference is set after flush, store its identity
+        $uow = $this->manager->getUnitOfWork();
+
+        if ($this->manager instanceof PhpcrDocumentManager) {
+            return $uow->contains($reference);
+        } else {
+            return $uow->isInIdentityMap($reference);
+        }
     }
 }


### PR DESCRIPTION
Unfortunately `isInIdentityMap` does not exist in Phpcr's DocumentManager which is raising issues when for example we're trying to `setReference` a document.

I'm not an expert in Doctrine stuff so I'm not sure if this is the right way to do it.

Related issue https://github.com/doctrine/phpcr-odm/issues/492