### PR TITLE
Fix of table names in ORMPurger

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -110,6 +110,8 @@ class ORMPurger implements PurgerInterface
 
         $commitOrder = $this->getCommitOrder($this->em, $classes);
 
+        $quoteStrategy = $this->em->getConfiguration()->getQuoteStrategy();
+
         // Get platform parameters
         $platform = $this->em->getConnection()->getDatabasePlatform();
 
@@ -128,7 +130,7 @@ class ORMPurger implements PurgerInterface
                 continue;
             }
 
-            $orderedTables[] = $class->getQuotedTableName($platform);
+            $orderedTables[] = $quoteStrategy->getTableName($class, $platform);
         }
 
         foreach($orderedTables as $tbl) {


### PR DESCRIPTION
In new ORM schame names are not part of table name. Best solution is to use Quiting strategy which is platform dependent.