### PR TITLE
allow the use of multiple transactions - one per file

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
@@ -141,6 +141,7 @@ abstract class AbstractExecutor
      *
      * @param array $fixtures Array of fixtures to execute.
      * @param boolean $append Whether to append the data fixtures or purge the database before loading.
+     * @param boolean $single_transaction Whether to use a single transaction when loading fixtures
      */
-    abstract public function execute(array $fixtures, $append = false);
+    abstract public function execute(array $fixtures, $append = false, $single_transaction = true);
 }

--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -77,16 +77,27 @@ class ORMExecutor extends AbstractExecutor
     }
 
     /** @inheritDoc */
-    public function execute(array $fixtures, $append = false)
+    public function execute(array $fixtures, $append = false, $single_transaction = true)
     {
-        $executor = $this;
-        $this->em->transactional(function(EntityManagerInterface $em) use ($executor, $fixtures, $append) {
-            if ($append === false) {
-                $executor->purge();
+        if($single_transaction) {
+            $executor = $this;
+            $this->em->transactional(function(EntityManager $em) use ($executor, $fixtures, $append) {
+                if ($append === false) {
+                    $executor->purge();
+                }
+                foreach ($fixtures as $fixture) {
+                    $executor->load($em, $fixture);
+                }
+            });
+        } else {
+            if($append === false) {
+                $this->purge();
             }
             foreach ($fixtures as $fixture) {
-                $executor->load($em, $fixture);
+                $this->em->beginTransaction();
+                $this->load($this->em, $fixture);
+                $this->em->commit();
             }
-        });
+        }
     }
 }


### PR DESCRIPTION
This allows the user to select whether they want a single transaction for all fixture files or one transaction per fixture file. This fixes a bug where I had a custom id generator that queries another table and increments an id there within its own transaction. It causes a segfault.

Fixes #126, #42 
This is the rebased version of PR #132 

That first PR was done prior to me really getting github PR workflow, and the attempted rebase failed. So here's the patch against latest master.
