### PR TITLE
quoteIdentifier on table name not required when deleting

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -135,8 +135,7 @@ class ORMPurger implements PurgerInterface
         $connection = $this->em->getConnection();
         foreach($orderedTables as $tbl) {
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-                $tbl = $connection->quoteIdentifier($tbl);
-                $connection->executeUpdate('DELETE FROM ' . $tbl );
+                $connection->executeUpdate('DELETE FROM ' . $tbl);
             } else {
                 $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }


### PR DESCRIPTION
`quoteIdentifier` on the table name isn't required, as it it already done by `getTableName` and the `QuoteStrategy` previously.

Infact, this double quoting breaks certain playforms under certain conditions. for example, on postgres with a reserved word table name (`name`), `DELETE FROM ""USER""` is executed, which throws an error.