### PR TITLE
Add ability to exclude tables from purge in ORM

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -141,18 +141,18 @@ class ORMPurger implements PurgerInterface
             $orderedTables[] = $this->getTableName($class, $platform);
         }
 
-        $connection = $this->em->getConnection();
-        $filterExpr = $connection->getConfiguration()->getFilterSchemaAssetsExpression();
-        $efe = empty($filterExpr);
-        foreach($orderedTables as $tbl) {
-            if(($efe||( !$efe && preg_match($filterExpr, $tbl) )) && array_search($tbl, $this->excluded)  === false){
-                if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-                    $connection->executeUpdate('DELETE FROM ' . $tbl);
-                } else {
-                    $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
-                }
-            }
-        }
+		$connection = $this->em->getConnection();
+		$filterExpr = $connection->getConfiguration()->getFilterSchemaAssetsExpression();
+		$emptyFilterExpression = empty($filterExpr);
+		foreach($orderedTables as $tbl) {
+			if(($emptyFilterExpression||preg_match($filterExpr, $tbl)) && array_search($tbl, $this->excluded) === false){
+				if ($this->purgeMode === self::PURGE_MODE_DELETE) {
+					$connection->executeUpdate("DELETE FROM " . $tbl);
+				} else {
+					$connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+				}
+			}
+		}
     }
 
     private function getCommitOrder(EntityManagerInterface $em, array $classes)

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -143,7 +143,7 @@ class ORMPurger implements PurgerInterface
 
         $connection = $this->em->getConnection();
         foreach($orderedTables as $tbl) {
-            if(array_search($tbl, $this->excluded) === false)){
+            if(array_search($tbl, $this->excluded)  === false){
                 if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                     $connection->executeUpdate('DELETE FROM ' . $tbl);
                 } else {

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -142,8 +142,10 @@ class ORMPurger implements PurgerInterface
         }
 
         $connection = $this->em->getConnection();
+        $filterExpr = $connection->getConfiguration()->getFilterSchemaAssetsExpression();
+        $efe = empty($filterExpr);
         foreach($orderedTables as $tbl) {
-            if(array_search($tbl, $this->excluded)  === false){
+            if(($efe||( !$efe && preg_match($filterExpr, $tbl) )) && array_search($tbl, $this->excluded)  === false){
                 if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                     $connection->executeUpdate('DELETE FROM ' . $tbl);
                 } else {

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -47,13 +47,22 @@ class ORMPurger implements PurgerInterface
     private $purgeMode = self::PURGE_MODE_DELETE;
 
     /**
+    * Table/view names to be excleded from purge
+    *
+    * @var string[]
+    */
+    private $excluded;
+
+    /**
      * Construct new purger instance.
      *
      * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
+     * @param string[] $excluded array of table/view names to be excleded from purge
      */
-    public function __construct(EntityManagerInterface $em = null)
+    public function __construct(EntityManagerInterface $em = null, array $excluded = array())
     {
         $this->em = $em;
+        $this->excluded = $excluded;
     }
 
     /**
@@ -134,10 +143,12 @@ class ORMPurger implements PurgerInterface
 
         $connection = $this->em->getConnection();
         foreach($orderedTables as $tbl) {
-            if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-                $connection->executeUpdate('DELETE FROM ' . $tbl);
-            } else {
-                $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+            if(array_search($tbl, $this->excluded) === false)){
+                if ($this->purgeMode === self::PURGE_MODE_DELETE) {
+                    $connection->executeUpdate('DELETE FROM ' . $tbl);
+                } else {
+                    $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+                }
             }
         }
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -1,0 +1,108 @@
+<?php
+namespace Doctrine\Tests\Common\DataFixtures;
+
+use Doctrine\Tests\Common\DataFixtures\BaseTest;
+
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\ExcludedEntity;
+use Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\IncludedEntity;
+
+/**
+ * 
+ *	@author Charles J. C. Elling, Jul 2, 2016
+ *
+ */
+class ORMPurgerExcludeTest extends BaseTest {
+	
+	const TEST_ENTITY_INCLUDED = 'Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\IncludedEntity';
+	const TEST_ENTITY_EXCLUDED = 'Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\ExcludedEntity';
+	
+	/**
+	 * Loads test data
+	 * 
+	 * @return \Doctrine\ORM\EntityManager
+	 */
+	protected function loadTestData(){
+		if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('Missing pdo_sqlite extension.');
+        }
+        
+        $dbParams = array('driver' => 'pdo_sqlite', 'memory' => true);
+        $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__.'/../TestPurgeEntity'), true);
+        $em = EntityManager::create($dbParams, $config);
+
+        $connection = $em->getConnection();
+        $configuration = $connection->getConfiguration();
+        $configuration->setFilterSchemaAssetsExpression(null);
+        
+        $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($em);
+        $schemaTool->dropDatabase();
+        $schemaTool->createSchema(array(
+	            $em->getClassMetadata(self::TEST_ENTITY_INCLUDED),
+	            $em->getClassMetadata(self::TEST_ENTITY_EXCLUDED)
+        ));
+		
+        $entity = new ExcludedEntity();
+        $entity->setId(1);
+        $em->persist($entity);
+        
+        $entity = new IncludedEntity();
+        $entity->setId(1);
+        $em->persist($entity);
+        
+        $em->flush();
+		
+		return $em;
+	}
+	
+	/**
+	 * Execute test purge
+	 * 
+	 * @param string|null $expression
+	 * @param array $list
+	 */
+	public function executeTestPurge($expression, array $list){
+		$em = $this->loadTestData();
+		$excludedRepository = $em->getRepository(self::TEST_ENTITY_EXCLUDED);
+		$includedRepository = $em->getRepository(self::TEST_ENTITY_INCLUDED);
+		
+		$excluded = $excludedRepository->findAll();
+		$included = $includedRepository->findAll();
+		
+		$this->assertGreaterThan(0, count($included));
+		$this->assertGreaterThan(0, count($excluded));
+		
+		$connection = $em->getConnection();
+		$configuration = $connection->getConfiguration();
+		$configuration->setFilterSchemaAssetsExpression($expression);
+		
+		$purger = new ORMPurger($em,$list);
+		$purger->purge();
+		
+		$excluded = $excludedRepository->findAll();
+		$included = $includedRepository->findAll();
+		
+		$this->assertEquals(0, count($included));
+		$this->assertGreaterThan(0, count($excluded));
+		
+	}
+	
+	/**
+	 * Test for purge exclusion usig dbal filter expression regexp.
+	 * 
+	 */
+	public function testPurgeExcludeUsingFilterExpression(){
+		$this->executeTestPurge('~^(?!ExcludedEntity)~', array());
+	}
+	
+	/**
+	 * Test for purge exclusion usig explicit exclution list.
+	 *
+	 */
+	public function testPurgeExcludeUsingList(){
+		$this->executeTestPurge(null,array('ExcludedEntity'));
+	}
+}

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures\TestPurgeEntity;
+
+/**
+ * 
+ * @author Charles J. C. Elling, Jul 4, 2016
+ * @Entity
+ */
+class ExcludedEntity{
+	
+    /**
+     * @Column(type="integer")
+     * @Id
+     */
+    private $id;
+
+    public function setId($id){
+        $this->id = $id;
+    }
+    
+	public function getId() {
+		return $this->id;
+	}
+}

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures\TestPurgeEntity;
+
+/**
+ * 
+ * @author Charles J. C. Elling, Jul 4, 2016
+ * @Entity
+ */
+class IncludedEntity{
+	
+    /**
+     * @Column(type="integer")
+     * @Id
+     */
+    private $id;
+
+    public function setId($id){
+        $this->id = $id;
+    }
+    
+	public function getId() {
+		return $this->id;
+	}
+}


### PR DESCRIPTION
Tests for  the  filter schema expression if present in the DBAL connection and checks is the table name has been explicitly excluded.