### PR TITLE
Added support for self referencing classes in the TopologicalSorter

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
+++ b/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
@@ -146,7 +146,7 @@ class TopologicalSorter
             $childDefinition = $this->nodeList[$dependency];
 
             // allow self referencing classes
-            if ($definition->value->getName() === $childDefinition->value->getName()) {
+            if ($definition === $childDefinition) {
                 continue;
             }
 

--- a/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
+++ b/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
@@ -145,6 +145,11 @@ class TopologicalSorter
 
             $childDefinition = $this->nodeList[$dependency];
 
+            // allow self referencing classes
+            if ($definition->value->getName() === $childDefinition->value->getName()) {
+                continue;
+            }
+
             switch ($childDefinition->state) {
                 case Vertex::VISITED:
                     break;

--- a/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
@@ -120,7 +120,7 @@ class TopologicalSorterTest extends \PHPUnit_Framework_TestCase
         $this->sorter->sort();
     }
 
-    public function testNoFailureOnSelfReferencingCyclicDependency()
+    public function testNoFailureOnSelfReferencingDependency()
     {
         $node1 = new Mock\Node(1);
         $node2 = new Mock\Node(2);

--- a/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
@@ -120,6 +120,32 @@ class TopologicalSorterTest extends \PHPUnit_Framework_TestCase
         $this->sorter->sort();
     }
 
+    public function testNoFailureOnSelfReferencingCyclicDependency()
+    {
+        $node1 = new Mock\Node(1);
+        $node2 = new Mock\Node(2);
+        $node3 = new Mock\Node(3);
+        $node4 = new Mock\Node(4);
+        $node5 = new Mock\Node(5);
+
+        $this->sorter->addNode('1', $node1);
+        $this->sorter->addNode('2', $node2);
+        $this->sorter->addNode('3', $node3);
+        $this->sorter->addNode('4', $node4);
+        $this->sorter->addNode('5', $node5);
+
+        $this->sorter->addDependency('1', '2');
+        $this->sorter->addDependency('1', '1');
+        $this->sorter->addDependency('2', '3');
+        $this->sorter->addDependency('3', '4');
+        $this->sorter->addDependency('5', '1');
+
+        $sortedList  = $this->sorter->sort();
+        $correctList = array($node4, $node3, $node2, $node1, $node5);
+
+        self::assertSame($correctList, $sortedList);
+    }
+
     public function testFailureSortMissingDependency()
     {
         $node1 = new Mock\Node(1);


### PR DESCRIPTION
A first solution to the issue #228. I don't know if this raises further issues.

- fixes #228 