### PR TITLE
Add a getFixture method

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -119,7 +119,10 @@ class Loader
     public function getFixture($className)
     {
         if (isset($this->fixtures[$className])) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not a registered fixture'));
+            throw new \InvalidArgumentException(sprintf(
+                '"%s" is not a registered fixture',
+                $className
+            ));
         }
 
         return $this->fixtures[$className];

--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -111,6 +111,21 @@ class Loader
     }
 
     /**
+     * Get a specific fixture instance
+     *
+     * @param string $className
+     * @return FixtureInterface
+     */
+    public function getFixture($className)
+    {
+        if (isset($this->fixtures[$className])) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not a registered fixture'));
+        }
+
+        return $this->fixtures[$className];
+    }
+
+    /**
      * Add a fixture object instance to the loader.
      *
      * @param FixtureInterface $fixture

--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -118,7 +118,7 @@ class Loader
      */
     public function getFixture($className)
     {
-        if (isset($this->fixtures[$className])) {
+        if (!isset($this->fixtures[$className])) {
             throw new \InvalidArgumentException(sprintf(
                 '"%s" is not a registered fixture',
                 $className

--- a/tests/Doctrine/Tests/Common/DataFixtures/LoaderTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/LoaderTest.php
@@ -22,6 +22,7 @@ namespace Doctrine\Tests\Common\DataFixtures;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\SharedFixtureInterface;
+use TestFixtures\MyFixture1;
 
 /**
  * Test fixtures loader.
@@ -62,5 +63,15 @@ class LoaderTest extends BaseTest
         $this->assertCount(5, $loader->getFixtures());
         $this->assertTrue($loader->isTransient('TestFixtures\NotAFixture'));
         $this->assertFalse($loader->isTransient('TestFixtures\MyFixture1'));
+    }
+
+    public function testGetFixture()
+    {
+        $loader = new Loader();
+        $loader->loadFromFile(__DIR__.'/TestFixtures/MyFixture1.php');
+
+        $fixture = $loader->getFixture(MyFixture1::class);
+
+        $this->assertInstanceOf(MyFixture1::class, $fixture);
     }
 }


### PR DESCRIPTION
I'm not sure if this is a good idea, but I've run into the case a few times where you need to get a fixture instance you didn't directly instantiate. Most often this happens when one fixture is automatically added by the loader as a dependency on another fixture.