### PR TITLE
Fix the sorting of metadata to be purged

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -165,7 +165,9 @@ class ORMPurger implements PurgerInterface
         $sorter = new TopologicalSorter();
 
         foreach ($classes as $class) {
-            $sorter->addNode($class->name, $class);
+            if ( ! $sorter->hasNode($class->name)) {
+                $sorter->addNode($class->name, $class);
+            }
 
             // $class before its parents
             foreach ($class->parentClasses as $parentClass) {


### PR DESCRIPTION
The node for a class could have been added in the TopologicalSorter before the class is processed itself, in case it is the target of an association in a previous class.
In this case, the node should not be overwritten, as this would make it forget all previous dependencies.