### PR TITLE
Fix sorter issue

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -165,7 +165,9 @@ class ORMPurger implements PurgerInterface
         $sorter = new TopologicalSorter();
 
         foreach ($classes as $class) {
-            $sorter->addNode($class->name, $class);
+            if ( ! $sorter->hasNode($class->name)) {
+                $sorter->addNode($class->name, $class);
+            }
 
             // $class before its parents
             foreach ($class->parentClasses as $parentClass) {
@@ -207,7 +209,7 @@ class ORMPurger implements PurgerInterface
             }
         }
 
-        return $sorter->sort();
+        return array_reverse($sorter->sort());
     }
 
     /**

--- a/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
+++ b/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
@@ -151,14 +151,10 @@ class TopologicalSorter
                 continue;
             }
 
-            switch ($childDefinition->state) {
-                case Vertex::VISITED:
-                case Vertex::IN_PROGRESS:
-                    break;
-
-                case Vertex::NOT_VISITED:
-                    $this->visit($childDefinition);
+            if ($childDefinition->state == Vertex::NOT_VISITED) {
+                $this->visit($childDefinition);
             }
+
         }
 
         $definition->state = Vertex::VISITED;

--- a/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
+++ b/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
@@ -153,19 +153,8 @@ class TopologicalSorter
 
             switch ($childDefinition->state) {
                 case Vertex::VISITED:
-                    break;
-
                 case Vertex::IN_PROGRESS:
-                    throw new CircularReferenceException(
-                        sprintf(
-                            'Graph contains cyclic dependency between the classes "%s" and'
-                            .' "%s". An example of this problem would be the following: '
-                            .'Class C has class B as its dependency. Then, class B has class A has its dependency. '
-                            .'Finally, class A has class C as its dependency.',
-                            $definition->value->getName(),
-                            $childDefinition->value->getName()
-                        )
-                    );
+                    break;
 
                 case Vertex::NOT_VISITED:
                     $this->visit($childDefinition);

--- a/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
+++ b/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
@@ -53,6 +53,23 @@ class TopologicalSorter
     private $sortedNodeList = [];
 
     /**
+     * Allow or not cyclic dependencies
+     *
+     * @var boolean
+     */
+    private $allowCyclicDependencies;
+
+    /**
+     * Construct TopologicalSorter object
+     *
+     * @param boolean $allowCyclicDependencies
+     */
+    public function __construct($allowCyclicDependencies = true)
+    {
+        $this->allowCyclicDependencies = $allowCyclicDependencies;
+    }
+
+    /**
      * Adds a new node (vertex) to the graph, assigning its hash and value.
      *
      * @param string        $hash
@@ -151,10 +168,26 @@ class TopologicalSorter
                 continue;
             }
 
-            if ($childDefinition->state == Vertex::NOT_VISITED) {
-                $this->visit($childDefinition);
+            switch ($childDefinition->state) {
+                case Vertex::VISITED:
+                    break;
+                case Vertex::IN_PROGRESS:
+                    if ( ! $this->allowCyclicDependencies) {
+                        throw new CircularReferenceException(
+                            sprintf(
+                                'Graph contains cyclic dependency between the classes "%s" and'
+                                .' "%s". An example of this problem would be the following: '
+                                .'Class C has class B as its dependency. Then, class B has class A has its dependency. '
+                                .'Finally, class A has class C as its dependency.',
+                                $definition->value->getName(),
+                                $childDefinition->value->getName()
+                            )
+                        );
+                    }
+                    break;
+                case Vertex::NOT_VISITED:
+                    $this->visit($childDefinition);
             }
-
         }
 
         $definition->state = Vertex::VISITED;

--- a/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
@@ -116,7 +116,9 @@ class TopologicalSorterTest extends \PHPUnit_Framework_TestCase
         $this->sorter->addDependency('2', '3');
         $this->sorter->addDependency('3', '1');
 
-        $this->expectException(CircularReferenceException::class);
+        $sortedList  = $this->sorter->sort();
+
+        self::assertSame(array($node3, $node2, $node1), $sortedList);
 
         $this->sorter->sort();
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
@@ -102,7 +102,7 @@ class TopologicalSorterTest extends \PHPUnit_Framework_TestCase
         self::assertSame($correctList, $sortedList);
     }
 
-    public function testFailureSortCyclicDependency()
+    public function testSortCyclicDependency()
     {
         $node1 = new ClassMetadata(1);
         $node2 = new ClassMetadata(2);


### PR DESCRIPTION
Fix #236 issue :

1/ On lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
- Node is not erased even if treated in dependencies
- Reverse sort result as previous version

2/ On lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
- Exception throwed according to new allowCyclicDependencies attribute

3/ On tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
- A new test is written for cyclic dependencies
