### PR TITLE
handle references for PHPCR ODM documents

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -86,6 +86,11 @@ class ReferenceRepository
         if (method_exists($uow, 'getEntityIdentifier')) {
             return $uow->getEntityIdentifier($reference);
         }
+        
+        // Dealing with PHPCR ODM UnitOfWork
+        if (method_exists($uow, 'getDocumentId')) {
+            return $uow->getDocumentId($reference);
+        }
 
         // ODM UnitOfWork
         return $uow->getDocumentIdentifier($reference);


### PR DESCRIPTION
Doing:

``` php
$this->addReference('test', $document);
```

throws an exception:

```
[Symfony\Component\Debug\Exception\UndefinedMethodException]
  Attempted to call an undefined method named "getDocumentIdentifier" of class "Doctrine\ODM\PHPCR\UnitOfWork".
```

when using references with PHPCR ODM documents.

The PHPCR ODM UnitOfWork class doesn't have the method `getDocumentIdentifier`. There is `getDocumentId` instead. MongoDB ODM seems to use `getDocumentIdentifier` method in its UnitOfWork class but not in PHPCR.

Please, let me know if its enough.
