### PR TITLE
Make sure entities that are marked readOnly are excluded from purge

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -112,7 +112,7 @@ class ORMPurger implements PurgerInterface
         $classes = array();
 
         foreach ($this->em->getMetadataFactory()->getAllMetadata() as $metadata) {
-            if (! $metadata->isMappedSuperclass && ! (isset($metadata->isEmbeddedClass) && $metadata->isEmbeddedClass)) {
+            if (! $metadata->isMappedSuperclass && ! (isset($metadata->isEmbeddedClass) && $metadata->isEmbeddedClass) && ! $metadata->isReadOnly) {
                 $classes[] = $metadata;
             }
         }


### PR DESCRIPTION
In my case this entity is implemented as a view, DELETE or TRUNCATE won't work.
Whatever the case, readOnly implies no changing the data.