### PR TITLE
ORMPurger: quote table names using reserved keywords

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Common\DataFixtures\Purger;
 
+use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Common\DataFixtures\Sorter\TopologicalSorter;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -244,7 +245,9 @@ class ORMPurger implements PurgerInterface
             return $class->table['schema'].'.'.$this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
         }
 
-        return $this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
+        $tableName = $this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
+        $tableAsset = new Table($tableName);
+        return $tableAsset->getQuotedName($platform);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -19,6 +19,7 @@ class ORMPurgerTest extends BaseTest
     const TEST_ENTITY_USER = 'Doctrine\Tests\Common\DataFixtures\TestEntity\User';
     const TEST_ENTITY_USER_WITH_SCHEMA = 'Doctrine\Tests\Common\DataFixtures\TestEntity\UserWithSchema';
     const TEST_ENTITY_QUOTED = 'Doctrine\Tests\Common\DataFixtures\TestEntity\Quoted';
+    const TEST_ENTITY_RESERVED_KEYWORD = 'Doctrine\Tests\Common\DataFixtures\TestEntity\ReservedKeyword';
 
 
     public function testGetAssociationTables()
@@ -65,4 +66,16 @@ class ORMPurgerTest extends BaseTest
         $this->assertStringStartsWith('test_schema',$tableName);
     }
 
+    public function testTableNameQuotedIfReservedKeyword()
+    {
+        $em = $this->getMockAnnotationReaderEntityManager();
+        $metadata = $em->getClassMetadata(self::TEST_ENTITY_RESERVED_KEYWORD);
+        $platform = $em->getConnection()->getDatabasePlatform();
+        $purger = new ORMPurger($em);
+        $class = new ReflectionClass('Doctrine\Common\DataFixtures\Purger\ORMPurger');
+        $method = $class->getMethod('getTableName');
+        $method->setAccessible(true);
+        $tableName = $method->invokeArgs($purger, array($metadata, $platform));
+        $this->assertEquals($tableName, '"SELECT"');
+    }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/ReservedKeyword.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/ReservedKeyword.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
+
+/**
+ * @Entity
+ * @Table("SELECT")
+ */
+class ReservedKeyword
+{
+    /**
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue(strategy="IDENTITY")
+     */
+    private $id;
+}


### PR DESCRIPTION
While DBAL supports auto quoting reserved keywords, ORMPurger doesn't actually make use of it.
This PR fixes this issue, test case included.