### PR TITLE
Allow to return empty arrays in getDependencies() method

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -260,8 +260,8 @@ class Loader
                 
                 $this->validateDependencies($dependenciesClasses);
 
-                if (!is_array($dependenciesClasses) || empty($dependenciesClasses)) {
-                    throw new \InvalidArgumentException(sprintf('Method "%s" in class "%s" must return an array of classes which are dependencies for the fixture, and it must be NOT empty.', 'getDependencies', $fixtureClass));
+                if (!is_array($dependenciesClasses)) {
+                    throw new \InvalidArgumentException(sprintf('Method "%s" in class "%s" must return an array of classes which are dependencies for the fixture.', 'getDependencies', $fixtureClass));
                 }
 
                 if (in_array($fixtureClass, $dependenciesClasses)) {

--- a/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
@@ -169,6 +169,19 @@ class DependentFixtureTest extends BaseTest
         $this->assertInstanceOf(__NAMESPACE__ . '\BaseParentFixture1', array_shift($orderedFixtures));
         $this->assertInstanceOf(__NAMESPACE__ . '\DependentFixture1', array_shift($orderedFixtures));
     }
+
+    public function test_dependentFixtureInterfaceAllowsToDefineEmptyDependencies()
+    {
+        $loader = new Loader();
+        $loader->addFixture(new NonEmptyDependenciesFixture);
+        $loader->addFixture(new EmptyDependenciesFixture);
+
+        $orderedFixtures = $loader->getFixtures();
+
+        $this->assertCount(2, $orderedFixtures);
+        $this->assertInstanceOf(__NAMESPACE__ . '\EmptyDependenciesFixture', array_shift($orderedFixtures));
+        $this->assertInstanceOf(__NAMESPACE__ . '\NonEmptyDependenciesFixture', array_shift($orderedFixtures));
+    }
 }
 
 class DependentFixture1 implements FixtureInterface, DependentFixtureInterface
@@ -392,5 +405,29 @@ class OrderedByNumberFixture3 implements FixtureInterface, OrderedFixtureInterfa
     public function getOrder()
     {
         return 10;
+    }
+}
+
+class EmptyDependenciesFixture implements FixtureInterface, DependentFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {}
+
+    public function getDependencies()
+    {
+        return array();
+    }
+}
+
+class NonEmptyDependenciesFixture implements FixtureInterface, DependentFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {}
+
+    public function getDependencies()
+    {
+        return array(
+            'Doctrine\Tests\Common\DataFixtures\EmptyDependenciesFixture'
+        );
     }
 }


### PR DESCRIPTION
I've defined a base class for all my fixtures to simplify the application. This base class implements `DependentFixtureInterface` in case the fixture file needs to define its dependencies.

The problem is that some fixtures don't need this feature, so the base class returns an empty array in getDependencies() ... and that's not allowed.

Would you kindly consider merging this proposal? Thanks!