### PR TITLE
Fix syntax highlighting on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ $loader->loadFromDirectory('/path/to/MyDataFixtures');
 
 Or you can load a set of fixtures from a file:
 
-    $loader->loadFromFile('/path/to/MyDataFixtures/MyFixture1.php');
+```php
+$loader->loadFromFile('/path/to/MyDataFixtures/MyFixture1.php');
+```
 
 You can get the added fixtures using the getFixtures() method:
 


### PR DESCRIPTION
There is a _Code Block_ with no syntax highlighting and I noted that it was out of the this README's standard.

:)