### PR TITLE
Make the behaviour of DELETE and TRUNCATE purge methods consistent

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Common\DataFixtures\Sorter\TopologicalSorter;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 /**
@@ -146,7 +147,9 @@ class ORMPurger implements PurgerInterface
 		foreach($orderedTables as $tbl) {
 			if(($emptyFilterExpression||preg_match($filterExpr, $tbl)) && array_search($tbl, $this->excluded) === false){
 				if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-					$connection->executeUpdate("DELETE FROM `" . $tbl . "`");
+					$tblIdentifier = new Identifier($tbl);
+					$tblQuoted = $tblIdentifier->getQuotedName($platform);
+					$connection->executeUpdate("DELETE FROM " . $tblQuoted);
 				} else {
 					$connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
 				}

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -146,7 +146,7 @@ class ORMPurger implements PurgerInterface
 		foreach($orderedTables as $tbl) {
 			if(($emptyFilterExpression||preg_match($filterExpr, $tbl)) && array_search($tbl, $this->excluded) === false){
 				if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-					$connection->executeUpdate("DELETE FROM " . $tbl);
+					$connection->executeUpdate("DELETE FROM `" . $tbl . "`");
 				} else {
 					$connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
 				}


### PR DESCRIPTION
Currently, the ORMPurger behaves differently when the DELETE method is used instead of TRUNCATE. TRUNCATE results in a call that quotes keywords in table names, while DELETE does not. This PR adds the same call to the DELETE branch to make them behave the same.