### PR TITLE
Remove deprecated MongoDB ODM annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache:
 php:
   - 5.6
   - 7.0
+  - 7.1
   - nightly
-  - hhvm
 
 matrix:
   allow_failures:
@@ -19,12 +19,14 @@ matrix:
 services: mongodb
 
 before_install:
-  - "if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then echo 'extension = mongo.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
+  - "if [[ $TRAVIS_PHP_VERSION == '5.6' ]]; then echo 'extension = mongo.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi"
+  - "if [[ $TRAVIS_PHP_VERSION != '5.6' ]]; then pecl install mongodb; fi"
 
 before_script:
   - composer self-update
   - composer install --prefer-source
-  - "if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then composer require 'doctrine/mongodb-odm' '*@beta'; fi"
+  - "if [[ $TRAVIS_PHP_VERSION != '5.6' ]]; then composer require --ignore-platform-reqs alcaeus/mongo-php-adapter; fi"
+  - composer require doctrine/mongodb-odm
 
 script:
   - ./vendor/bin/phpunit -v

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "suggest": {
         "doctrine/orm": "For loading ORM fixtures",
         "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
-        "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+        "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures",
+        "alcaeus/mongo-php-adapter": "For using MongoDB ODM with PHP 7"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\DataFixtures\\": "lib/Doctrine/Common/DataFixtures" }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestDocument/Role.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestDocument/Role.php
@@ -15,7 +15,7 @@ class Role
     private $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      * @ODM\Index
      */
     private $name;


### PR DESCRIPTION
Fixes #263.

The `String`, `Int` (and a few more) type annotations are deprecated and not loaded in PHP 7. This PR replaces them.

It also uses mongo-php-adapter to run ODM tests in PHP 7 and drops HHVM tests from travis-ci. I'll  create a pull request to bring the dependencies inline with other projects next.