### PR TITLE
Disable foreign key checks on purge for all MySQL versions

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\Common\DataFixtures\Purger;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Common\DataFixtures\Sorter\TopologicalSorter;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -148,7 +150,7 @@ class ORMPurger implements PurgerInterface
                 if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                     $connection->executeUpdate("DELETE FROM " . $tbl);
                 } else {
-                    $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
+                    $connection->executeUpdate($this->getTruncateTableSQL($platform, $connection, $tbl));
                 }
             }
         }
@@ -261,5 +263,23 @@ class ORMPurger implements PurgerInterface
         }
 
         return $this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);
+    }
+
+    /**
+     * @param AbstractPlatform $platform
+     * @param Connection       $connection
+     * @param string           $tbl
+     *
+     * @return string
+     */
+    private function getTruncateTableSQL(AbstractPlatform $platform, Connection $connection, $tbl)
+    {
+        $sql = $platform->getTruncateTableSQL($tbl, true);
+
+        if ($connection->getDriver() instanceof AbstractMySQLDriver) {
+            $sql = 'SET FOREIGN_KEY_CHECKS = 0;'.$sql.';SET FOREIGN_KEY_CHECKS = 1;';
+        }
+
+        return $sql;
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures;
+
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+use ReflectionClass;
+
+/**
+ * @author Robert Freigang <robertfreigang@gmx.de>
+ *
+ * @covers ORMPurger::getTruncateTableSQL
+ */
+class ORMPurgerForeignKeyCheckTest extends BaseTest
+{
+    const FOREIGN_KEY_CHECK_STRING_START = 'SET FOREIGN_KEY_CHECKS = 0;';
+    const FOREIGN_KEY_CHECK_STRING_END = ';SET FOREIGN_KEY_CHECKS = 1;';
+    const TEST_TABLE_NAME = 'test_table_name';
+
+    /**
+     * @param Driver $driver
+     * @param bool   $hasForeignKeyCheckString
+     *
+     * @dataProvider purgeForDifferentDriversProvider
+     */
+    public function testPurgeForDifferentDrivers(Driver $driver, $hasForeignKeyCheckString)
+    {
+        $truncateTableSQL = $this->getTruncateTableSQLForDriver($driver);
+
+        if ($hasForeignKeyCheckString) {
+            $this->assertStringStartsWith(self::FOREIGN_KEY_CHECK_STRING_START, $truncateTableSQL);
+            $this->assertStringEndsWith(self::FOREIGN_KEY_CHECK_STRING_END, $truncateTableSQL);
+        } else {
+            $this->assertNotContains(self::FOREIGN_KEY_CHECK_STRING_START, $truncateTableSQL);
+            $this->assertNotContains(self::FOREIGN_KEY_CHECK_STRING_END, $truncateTableSQL);
+        }
+
+        $this->assertContains(self::TEST_TABLE_NAME, $truncateTableSQL);
+    }
+
+    /**
+     * @return array
+     */
+    public function purgeForDifferentDriversProvider()
+    {
+        return [
+            [$this->createMock(AbstractMySQLDriver::class), true],
+            [$this->createMock(AbstractSQLiteDriver::class), false],
+        ];
+    }
+
+    /**
+     * @param Driver $driver
+     *
+     * @return string
+     */
+    private function getTruncateTableSQLForDriver(Driver $driver)
+    {
+        $em = $this->getMockAnnotationReaderEntityManager();
+
+        $platform = $em->getConnection()->getDatabasePlatform();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDriver')->willReturn($driver);
+
+        $purger = new ORMPurger($em);
+        $purgerClass = new ReflectionClass(ORMPurger::class);
+        $getTruncateTableSQLMethod = $purgerClass->getMethod('getTruncateTableSQL');
+        $getTruncateTableSQLMethod->setAccessible(true);
+
+        $truncateTableSQL = $getTruncateTableSQLMethod->invokeArgs(
+            $purger,
+            [$platform, $connection, self::TEST_TABLE_NAME]
+        );
+
+        return $truncateTableSQL;
+    }
+}


### PR DESCRIPTION
... when purge mode is truncate

* add test for change of foreign key check when using MySQL
* add test for not set foreign key check when using SQLite

---

As statet in https://github.com/doctrine/dbal/pull/2620 doctrine/dbal is not responsible for this ("third party code has to built its own implementation around this because it is highly use-case specific").
So I give it a try to finish this long term never ending story. 

Closes (stale?) PR #127 and fixes #113.