### PR TITLE
Symfony 4 support: Hook point to control creating fixtures objects

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -153,7 +153,7 @@ class Loader
                 $this->orderFixturesByDependencies = true;
                 foreach($fixture->getDependencies() as $class) {
                     if (class_exists($class)) {
-                        $this->addFixture(new $class);
+                        $this->addFixture($this->createFixture($class));
                     }
                 }
             }
@@ -197,6 +197,17 @@ class Loader
 
         $interfaces = class_implements($className);
         return in_array(FixtureInterface::class, $interfaces) ? false : true;
+    }
+
+    /**
+     * Creates the fixture object from the class.
+     *
+     * @param string $class
+     * @return FixtureInterface
+     */
+    protected function createFixture($class)
+    {
+        return new $class();
     }
 
     /**
@@ -376,7 +387,7 @@ class Loader
             $sourceFile = $reflClass->getFileName();
 
             if (in_array($sourceFile, $includedFiles) && ! $this->isTransient($className)) {
-                $fixture = new $className;
+                $fixture = $this->createFixture($className);
                 $fixtures[] = $fixture;
                 $this->addFixture($fixture);
             }


### PR DESCRIPTION
Hi guys!

This small patch is needed to support Symfony 4. Specifically, in doctrine/DoctrineFixturesBundle#209, we re-work fixtures to make the classes proper services, which is an easy patch.

However, in this parent class, there are 2 spots where the fixture objects are *instantiated*. That's a problem: the *container* should instantiate them. With this patch, in the bundle, we will be able to throw an exception in `createFixture()` if the object is not already available as a service.

Thanks!
