### PR TITLE
Use assertEmpty

### DIFF
--- a/tests/Doctrine/Tests/Common/DataFixtures/Sorter/VertexTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Sorter/VertexTest.php
@@ -38,6 +38,6 @@ class VertexTest extends BaseTest
 
         self::assertSame($value, $node->value);
         self::assertSame(Vertex::NOT_VISITED, $node->state);
-        self::assertSame([], $node->dependencyList);
+        self::assertEmpty($node->dependencyList);
     }
 }


### PR DESCRIPTION
Small one: I've refactored a test with [`assertEmpty`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertEmpty) method.