### PR TITLE
Don't use ignore-platform-reqs when installing mongo-php-adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 services: mongodb
 
 before_install:
-  - pecl install mongodb
+  - pecl install -f mongodb
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ before_install:
 before_script:
   - composer self-update
   - composer install --prefer-source
-  - composer require --ignore-platform-reqs alcaeus/mongo-php-adapter
+  - composer config "platform.ext-mongo" "1.6.16"
+  - composer require alcaeus/mongo-php-adapter
   - composer require doctrine/mongodb-odm
 
 script:


### PR DESCRIPTION
Using `ignore-platform-reqs` can cause a bunch of errors down the line (e.g. by installing incompatible package versions not suited for the current PHP version). Thus, `ext-mongodb` is provided via `config.platform`.