### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
@@ -87,14 +87,14 @@ class DependentFixtureTest extends BaseTest
         // BaseParentFixture1 has no dependencies, so it will always be first in this case
         $this->assertEquals($baseParentFixtureOrder, 0);
 
-        $this->assertTrue($contactFixtureOrder > $contactMethodFixtureOrder);
-        $this->assertTrue($contactFixtureOrder > $addressFixtureOrder);
-        $this->assertTrue($contactFixtureOrder > $countryFixtureOrder);
-        $this->assertTrue($contactFixtureOrder > $stateFixtureOrder);
-        $this->assertTrue($contactFixtureOrder > $contactMethodFixtureOrder);
+        $this->assertGreaterThan($contactMethodFixtureOrder, $contactFixtureOrder);
+        $this->assertGreaterThan($addressFixtureOrder, $contactFixtureOrder);
+        $this->assertGreaterThan($countryFixtureOrder, $contactFixtureOrder);
+        $this->assertGreaterThan($stateFixtureOrder, $contactFixtureOrder);
+        $this->assertGreaterThan($contactMethodFixtureOrder, $contactFixtureOrder);
 
-        $this->assertTrue($addressFixtureOrder > $stateFixtureOrder);
-        $this->assertTrue($addressFixtureOrder > $countryFixtureOrder);
+        $this->assertGreaterThan($stateFixtureOrder, $addressFixtureOrder);
+        $this->assertGreaterThan($countryFixtureOrder, $addressFixtureOrder);
     }
 
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorSharedFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorSharedFixtureTest.php
@@ -79,13 +79,13 @@ class ORMExecutorSharedFixtureTest extends BaseTest
         $referenceRepository = $executor->getReferenceRepository();
         $references = $referenceRepository->getReferences();
 
-        $this->assertEquals(2, count($references));
+        $this->assertCount(2, $references);
         $roleReference = $referenceRepository->getReference('admin-role');
-        $this->assertTrue($roleReference instanceof Role);
+        $this->assertInstanceOf(Role::class, $roleReference);
         $this->assertEquals('admin', $roleReference->getName());
 
         $userReference = $referenceRepository->getReference('admin');
-        $this->assertTrue($userReference instanceof User);
+        $this->assertInstanceOf(User::class, $userReference);
         $this->assertEquals('admin@example.com', $userReference->getEmail());
     }
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -80,7 +80,7 @@ class ORMPurgerExcludeTest extends BaseTest
         $excluded = $excludedRepository->findAll();
         $included = $includedRepository->findAll();
 
-        $this->assertEquals(0, count($included));
+        $this->assertCount(0, $included);
         $this->assertGreaterThan(0, count($excluded));
     }
 


### PR DESCRIPTION
I've refactored some tests, like #275, this time using:
- `assertInstanceOf` instead of `instanceof` operator;
- `assertCount` instead of `count` function;
- `assertGreaterThan` for mathematical comparisons;