### PR TITLE
Allowing getDependencies() to be empty

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -271,8 +271,8 @@ class Loader
                 
                 $this->validateDependencies($dependenciesClasses);
 
-                if (!is_array($dependenciesClasses) || empty($dependenciesClasses)) {
-                    throw new \InvalidArgumentException(sprintf('Method "%s" in class "%s" must return an array of classes which are dependencies for the fixture, and it must be NOT empty.', 'getDependencies', $fixtureClass));
+                if (!is_array($dependenciesClasses)) {
+                    throw new \InvalidArgumentException(sprintf('Method "%s" in class "%s" must return an array of classes which are dependencies for the fixture.', 'getDependencies', $fixtureClass));
                 }
 
                 if (in_array($fixtureClass, $dependenciesClasses)) {

--- a/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
@@ -169,6 +169,17 @@ class DependentFixtureTest extends BaseTest
         $this->assertInstanceOf(BaseParentFixture1::class, array_shift($orderedFixtures));
         $this->assertInstanceOf(DependentFixture1::class, array_shift($orderedFixtures));
     }
+
+    public function test_dependentFixtureInterfaceAllowsToDefineEmptyDependencies()
+    {
+        $loader = new Loader();
+        $loader->addFixture(new NonEmptyDependenciesFixture);
+        $loader->addFixture(new EmptyDependenciesFixture);
+        $orderedFixtures = $loader->getFixtures();
+        $this->assertCount(2, $orderedFixtures);
+        $this->assertInstanceOf(__NAMESPACE__ . '\EmptyDependenciesFixture', array_shift($orderedFixtures));
+        $this->assertInstanceOf(__NAMESPACE__ . '\NonEmptyDependenciesFixture', array_shift($orderedFixtures));
+    }
 }
 
 class DependentFixture1 implements FixtureInterface, DependentFixtureInterface
@@ -376,5 +387,26 @@ class OrderedByNumberFixture3 implements FixtureInterface, OrderedFixtureInterfa
     public function getOrder()
     {
         return 10;
+    }
+}
+
+class EmptyDependenciesFixture implements FixtureInterface, DependentFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {}
+    public function getDependencies()
+    {
+        return array();
+    }
+}
+class NonEmptyDependenciesFixture implements FixtureInterface, DependentFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {}
+    public function getDependencies()
+    {
+        return array(
+            'Doctrine\Tests\Common\DataFixtures\EmptyDependenciesFixture'
+        );
     }
 }


### PR DESCRIPTION
Hi guys!

I'm re-proposing this idea, as it continues to be a little "usability" thorn. But now, we have slightly different reasons for how I would like to expose this to users. Basically:

1) I think defining `getDependencies()` is the best way or ordering your fixtures
2) In the Symfony world, we will likely add a `make:fixtures` command to generate the class for you
3) I would love to generate a skeleton that already has the `getDependencies()` method defined. It would default to empty. If the user never cares, they will just ignore it.

By allowing `getDependencies()` to be empty, we can "nudge" the user towards this "best way" of defining fixture ordering by generating this method for them. This makes the feature "discoverable".

Thanks!