### PR TITLE
Added access modifier to DependentFixtureInterface

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
@@ -33,5 +33,5 @@ interface DependentFixtureInterface
      *
      * @return array
      */
-    function getDependencies();
+    public function getDependencies();
 }


### PR DESCRIPTION
Implement the access modifier making it PSR-2 compliant.

Just noticed that using some IDE functionality to implement this interface copy/paste the code from it and later marks it as an "error". 
Because doctrine is using PSR-2, i think it makes sense making this one compliant too.