### PR TITLE
Fix issue referencing a non string object ID

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -52,7 +52,7 @@ class ProxyReferenceRepository extends ReferenceRepository
             $simpleReferences[$name] = [$className, $this->getIdentifier($reference, $unitOfWork)];
         }
 
-        $serializedData = json_encode([
+        $serializedData = serialize([
             'references' => $simpleReferences,
             'identities' => $this->getIdentities(),
         ]);
@@ -67,7 +67,7 @@ class ProxyReferenceRepository extends ReferenceRepository
      */
     public function unserialize($serializedData)
     {
-        $repositoryData = json_decode($serializedData, true);
+        $repositoryData = unserialize($serializedData);
         $references     = $repositoryData['references'];
 
         foreach ($references as $name => $proxyReference) {

--- a/tests/Doctrine/Tests/Common/DataFixtures/BaseTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/BaseTest.php
@@ -3,8 +3,10 @@
 namespace Doctrine\Tests\Common\DataFixtures;
 
 use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
+use Doctrine\Tests\Common\DataFixtures\TestType\RoleIdType;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -36,8 +38,17 @@ abstract class BaseTest extends TestCase
      */
     protected function getMockSqliteEntityManager()
     {
+        $this->registerCustomTypes();
+
         $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
         $config = Setup::createAnnotationMetadataConfiguration([__DIR__.'/TestEntity'], true);
         return EntityManager::create($dbParams, $config);
+    }
+
+    protected function registerCustomTypes(): void
+    {
+        if (!Type::hasType(RoleIdType::NAME)) {
+            Type::addType(RoleIdType::NAME, RoleIdType::class);
+        }
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Tests\Common\DataFixtures\TestEntity\Role;
+use Doctrine\Tests\Common\DataFixtures\TestEntity\RoleId;
 
 /**
  * Test ProxyReferenceRepository.
@@ -23,8 +24,6 @@ class ProxyReferenceRepositoryTest extends BaseTest
         $em = $this->getMockAnnotationReaderEntityManager();
         $role = new TestEntity\Role;
         $role->setName('admin');
-        $meta = $em->getClassMetadata(self::TEST_ENTITY_ROLE);
-        $meta->getReflectionProperty('id')->setValue($role, 1);
 
         $referenceRepo = new ProxyReferenceRepository($em);
         $referenceRepo->addReference('test', $role);
@@ -61,7 +60,7 @@ class ProxyReferenceRepositoryTest extends BaseTest
 
         $referenceRepository->expects($this->once())
             ->method('setReferenceIdentity')
-            ->with('admin-role', ['id' => 1]);
+            ->with('admin-role', ['id' => new RoleId('uuid')]);
 
         $roleFixture = new TestFixtures\RoleFixture;
         $roleFixture->setReferenceRepository($referenceRepository);

--- a/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\Common\DataFixtures\TestEntity\Role;
+use Doctrine\Tests\Common\DataFixtures\TestEntity\RoleId;
 use Prophecy\Prophecy\ProphecyInterface;
 
 /**
@@ -64,7 +65,7 @@ class ReferenceRepositoryTest extends BaseTest
 
         $referenceRepository->expects($this->once())
             ->method('setReferenceIdentity')
-            ->with('admin-role', ['id' => 1]);
+            ->with('admin-role', ['id' => new RoleId('uuid')]);
 
         $roleFixture = new TestFixtures\RoleFixture;
         $roleFixture->setReferenceRepository($referenceRepository);

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Role.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Role.php
@@ -8,9 +8,8 @@ namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
 class Role
 {
     /**
-     * @Column(type="integer")
+     * @Column(type="role_id")
      * @Id
-     * @GeneratedValue(strategy="IDENTITY")
      */
     private $id;
 
@@ -18,6 +17,15 @@ class Role
      * @Column(length=50)
      */
     private $name;
+
+    /**
+     * Role constructor.
+     * @param $id
+     */
+    public function __construct($id = null)
+    {
+        $this->id = $id ?? new RoleId('uuid');
+    }
 
     public function getId()
     {

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/RoleId.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/RoleId.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
+
+/**
+ * @Entity
+ */
+class RoleId
+{
+    /** @var string */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getValue();
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestType/RoleIdType.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestType/RoleIdType.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures\TestType;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\Tests\Common\DataFixtures\TestEntity\RoleId;
+
+class RoleIdType extends StringType
+{
+    const NAME = 'role_id';
+
+    public function getName()
+    {
+        return static::NAME;
+    }
+
+    /**
+     * @param string $value
+     * @param AbstractPlatform $platform
+     *
+     * @return null|RoleId
+     *
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        return new RoleId($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param RoleId|null $value
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if (!$value instanceof RoleId) {
+            throw ConversionException::conversionFailed($value, static::NAME);
+        }
+
+        return $value->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     *
+     * @return boolean
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}
+


### PR DESCRIPTION
When using Value Object as IDs in Doctrine, the ProxyReferenceRepository fails to unserialize the reference repository. This is caused by the fact that `json_encode` and `json_decode` does not know how to persist information about these objects (as it expects to have a plain data structure with string for IDs).

This PR solves it by using `serialize` and `unserialize` instead.