### PR TITLE
Version 2: Make executors and purgers final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] - unreleased
+
+### Changed
+
+ - [290: Make purgers and executors final](https://github.com/doctrine/data-fixtures/pull/290) - @dbu
+
 ## [1.3.0] - 2017-11-27
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     },
     "conflict": {

--- a/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
@@ -10,7 +10,9 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\DataFixtures\Purger\PurgerInterface;
 
 /**
- * Abstract fixture executor.
+ * The fixture executor is responsible for executing a set of fixtures.
+ *
+ * It can trigger the purger before executing the fixtures to reset the database first.
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
  */

--- a/lib/Doctrine/Common/DataFixtures/Executor/MongoDBExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/MongoDBExecutor.php
@@ -12,13 +12,8 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
  */
-class MongoDBExecutor extends AbstractExecutor
+final class MongoDBExecutor extends AbstractExecutor
 {
-    /**
-     * Construct new fixtures loader instance.
-     *
-     * @param DocumentManager $dm DocumentManager instance used for persistence.
-     */
     public function __construct(DocumentManager $dm, MongoDBPurger $purger = null)
     {
         $this->dm = $dm;
@@ -31,12 +26,7 @@ class MongoDBExecutor extends AbstractExecutor
         $dm->getEventManager()->addEventSubscriber($this->listener);
     }
 
-    /**
-     * Retrieve the DocumentManager instance this executor instance is using.
-     *
-     * @return \Doctrine\ODM\MongoDB\DocumentManager
-     */
-    public function getObjectManager()
+    public function getObjectManager(): DocumentManager
     {
         return $this->dm;
     }

--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -12,18 +12,13 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
  */
-class ORMExecutor extends AbstractExecutor
+final class ORMExecutor extends AbstractExecutor
 {
     /**
      * @var EntityManagerInterface
      */
     private $em;
-    
-    /**
-     * Construct new fixtures loader instance.
-     *
-     * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
-     */
+
     public function __construct(EntityManagerInterface $em, ORMPurger $purger = null)
     {
         $this->em = $em;
@@ -36,12 +31,7 @@ class ORMExecutor extends AbstractExecutor
         $em->getEventManager()->addEventSubscriber($this->listener);
     }
 
-    /**
-     * Retrieve the EntityManagerInterface instance this executor instance is using.
-     *
-     * @return \Doctrine\ORM\EntityManagerInterface
-     */
-    public function getObjectManager()
+    public function getObjectManager(): EntityManagerInterface
     {
         return $this->em;
     }

--- a/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
@@ -11,7 +11,7 @@ use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  */
-class PHPCRExecutor extends AbstractExecutor
+final class PHPCRExecutor extends AbstractExecutor
 {
     /**
      * @var DocumentManagerInterface
@@ -33,7 +33,7 @@ class PHPCRExecutor extends AbstractExecutor
         }
     }
 
-    public function getObjectManager()
+    public function getObjectManager(): DocumentManagerInterface
     {
         return $this->dm;
     }

--- a/lib/Doctrine/Common/DataFixtures/Purger/MongoDBPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/MongoDBPurger.php
@@ -9,37 +9,24 @@ use Doctrine\ODM\MongoDB\DocumentManager;
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
  */
-class MongoDBPurger implements PurgerInterface
+final class MongoDBPurger implements PurgerInterface
 {
-    /** DocumentManager instance used for persistence. */
+    /**
+     * @var DocumentManager
+     */
     private $dm;
 
-    /**
-     * Construct new purger instance.
-     *
-     * @param DocumentManager $dm DocumentManager instance used for persistence.
-     */
     public function __construct(DocumentManager $dm = null)
     {
         $this->dm = $dm;
     }
 
-    /**
-     * Set the DocumentManager instance this purger instance should use.
-     *
-     * @param DocumentManager $dm
-     */
     public function setDocumentManager(DocumentManager $dm)
     {
         $this->dm = $dm;
     }
 
-    /**
-     * Retrieve the DocumentManager instance this purger instance is using.
-     *
-     * @return \Doctrine\ODM\MongoDB\DocumentManager
-     */
-    public function getObjectManager()
+    public function getObjectManager(): DocumentManager
     {
         return $this->dm;
     }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -14,12 +14,14 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
-class ORMPurger implements PurgerInterface
+final class ORMPurger implements PurgerInterface
 {
     const PURGE_MODE_DELETE = 1;
     const PURGE_MODE_TRUNCATE = 2;
 
-    /** EntityManagerInterface instance used for persistence. */
+    /**
+     * @var EntityManagerInterface
+     */
     private $em;
 
     /**
@@ -30,15 +32,13 @@ class ORMPurger implements PurgerInterface
     private $purgeMode = self::PURGE_MODE_DELETE;
 
     /**
-    * Table/view names to be excleded from purge
+    * Table/view names to be excluded from purge
     *
     * @var string[]
     */
     private $excluded;
 
     /**
-     * Construct new purger instance.
-     *
      * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
      * @param string[] $excluded array of table/view names to be excleded from purge
      */
@@ -48,43 +48,22 @@ class ORMPurger implements PurgerInterface
         $this->excluded = $excluded;
     }
 
-    /**
-     * Set the purge mode
-     *
-     * @param $mode
-     * @return void
-     */
-    public function setPurgeMode($mode)
+    public function setPurgeMode(int $mode)
     {
         $this->purgeMode = $mode;
     }
 
-    /**
-     * Get the purge mode
-     *
-     * @return int
-     */
-    public function getPurgeMode()
+    public function getPurgeMode(): int
     {
         return $this->purgeMode;
     }
 
-    /**
-     * Set the EntityManagerInterface instance this purger instance should use.
-     *
-     * @param EntityManagerInterface $em
-     */
     public function setEntityManager(EntityManagerInterface $em)
     {
       $this->em = $em;
     }
 
-    /**
-     * Retrieve the EntityManagerInterface instance this purger instance is using.
-     *
-     * @return \Doctrine\ORM\EntityManagerInterface
-     */
-    public function getObjectManager()
+    public function getObjectManager(): EntityManagerInterface
     {
         return $this->em;
     }
@@ -143,7 +122,7 @@ class ORMPurger implements PurgerInterface
      *
      * @return ClassMetadata[]
      */
-    private function getCommitOrder(EntityManagerInterface $em, array $classes)
+    private function getCommitOrder(EntityManagerInterface $em, array $classes): array
     {
         $sorter = new TopologicalSorter();
 
@@ -195,12 +174,7 @@ class ORMPurger implements PurgerInterface
         return array_reverse($sorter->sort());
     }
 
-    /**
-     * @param array $classes
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     * @return array
-     */
-    private function getAssociationTables(array $classes, AbstractPlatform $platform)
+    private function getAssociationTables(array $classes, AbstractPlatform $platform): array
     {
         $associationTables = [];
 
@@ -215,13 +189,7 @@ class ORMPurger implements PurgerInterface
         return $associationTables;
     }
 
-    /**
-     *
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     * @return string
-     */
-    private function getTableName($class, $platform)
+    private function getTableName(ClassMetadata $class, AbstractPlatform $platform): string
     {
         if (isset($class->table['schema']) && !method_exists($class, 'getSchemaName')) {
             return $class->table['schema'].'.'.$this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
@@ -230,14 +198,7 @@ class ORMPurger implements PurgerInterface
         return $this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
     }
 
-    /**
-     *
-     * @param array            $association
-     * @param \Doctrine\ORM\Mapping\ClassMetadata    $class
-     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
-     * @return string
-     */
-    private function getJoinTableName($assoc, $class, $platform)
+    private function getJoinTableName(array $assoc, ClassMetadata $class, AbstractPlatform $platform): string
     {
         if (isset($assoc['joinTable']['schema']) && !method_exists($class, 'getSchemaName')) {
             return $assoc['joinTable']['schema'].'.'.$this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);

--- a/lib/Doctrine/Common/DataFixtures/Purger/PHPCRPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/PHPCRPurger.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Common\DataFixtures\Purger;
 
-use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
 use PHPCR\Util\NodeHelper;
 
@@ -11,7 +10,7 @@ use PHPCR\Util\NodeHelper;
  *
  * @author Daniel Barsotti <daniel.barsotti@liip.ch>
  */
-class PHPCRPurger implements PurgerInterface
+final class PHPCRPurger implements PurgerInterface
 {
     /**
      * @var DocumentManagerInterface
@@ -23,12 +22,12 @@ class PHPCRPurger implements PurgerInterface
         $this->dm = $dm;
     }
 
-    public function setDocumentManager(DocumentManager $dm)
+    public function setDocumentManager(DocumentManagerInterface $dm)
     {
         $this->dm = $dm;
     }
 
-    public function getObjectManager()
+    public function getObjectManager(): DocumentManagerInterface
     {
         return $this->dm;
     }


### PR DESCRIPTION
This is a follow up to #289 (and will show the changes from #289 until it is merged) to make purgers and executors final and add return type and method type declarations where possible. i also remove pointless phpdoc comments.

This bumps the version to 2 - i suggest to keep this open and wait with merging until you feel ready to start the 2.0 version.