### PR TITLE
fix(loader): don't create fixture dependency if already added

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -135,7 +135,7 @@ class Loader
             } elseif ($fixture instanceof DependentFixtureInterface) {
                 $this->orderFixturesByDependencies = true;
                 foreach($fixture->getDependencies() as $class) {
-                    if (class_exists($class)) {
+                    if (!isset($this->fixtures[$fixtureClass]) && class_exists($class)) {
                         $this->addFixture($this->createFixture($class));
                     }
                 }


### PR DESCRIPTION
I outlined this below on Slack:

Symfony4, DoctrineFixturesBundle 3.4, LiipFunctionalTestingBundle.
I have a Fixture A which depends on Fixture B.
Fixture B has constructor dependency injection going on, so the LiipFunctionalTesting bundle loads that from the container [(see here)](https://github.com/liip/LiipFunctionalTestBundle/blob/master/Test/WebTestCase.php#L713) and calls ->addFixture on the loader.

Tracing it through, I can see here that we're doing a plain ol instantiation of the class, even if the fixture is already loaded - [Loader.php#L139](https://github.com/doctrine/data-fixtures/blob/master/lib/Doctrine/Common/DataFixtures/Loader.php#L139)

We can also definitely fix this in the LiipFunctionalTestingBundle by creating a custom Loader and overriding the createFixture method to use the Container to resolve it instead, but it also seems logical to me that this package doesn't try to create another fixture if it has already been added.

Let me know your thoughts :)