### PR TITLE
Enhancement: Use SVG badge for Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Doctrine Data Fixtures Extension
 
-[![Build Status](https://travis-ci.org/doctrine/data-fixtures.png)](https://travis-ci.org/doctrine/data-fixtures)
+[![Build Status](https://travis-ci.org/doctrine/data-fixtures.svg?branch=master)](https://travis-ci.org/doctrine/data-fixtures)
 
 This extension aims to provide a simple way to manage and execute the loading of data fixtures
 for the [Doctrine ORM or ODM](http://www.doctrine-project.org/). You can write fixture classes


### PR DESCRIPTION
This PR

* [x] uses an SVG badge for displaying the Travis CI build status in `README.md`