### PR TITLE
Fix: No need to update composer itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
   - pecl install -f mongodb
 
 before_script:
-  - composer self-update
   - composer install --prefer-source
   - composer config "platform.ext-mongo" "1.6.16"
   - composer require alcaeus/mongo-php-adapter


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself on Travis (again)