### PR TITLE
Doctrine\Common\Persistence\ObjectManager is deprecated

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Common\DataFixtures;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectManager as DeprecatedManager;
+use Doctrine\Persistence\ObjectManager;
 
 /**
  * Interface contract for fixture classes to implement.
@@ -13,6 +14,7 @@ interface FixtureInterface
 {
     /**
      * Load data fixtures with the passed EntityManager
+     * @param ObjectManager|DeprecatedManager $manager
      */
-    public function load(ObjectManager $manager);
+    public function load($manager);
 }


### PR DESCRIPTION
... but you cant use the new Doctrine\Persistence\ObjectManager because of TypeHinting.

Found that on the FixtureBundle 3.3 in Symfony 5.