### PR TITLE
Add correct return type to DependentFixtureInterface::getDependencies

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
@@ -13,7 +13,7 @@ interface DependentFixtureInterface
      * This method must return an array of fixtures classes
      * on which the implementing class depends on
      *
-     * @return array
+     * @return class-string[]
      */
     public function getDependencies();
 }


### PR DESCRIPTION
This makes it easier for PHPStan to understand what's going on.