### PR TITLE
Quote table names that also are reserved keywords

### DIFF
--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -15,6 +15,7 @@ class ORMPurgerTest extends BaseTest
     public const TEST_ENTITY_USER             = TestEntity\User::class;
     public const TEST_ENTITY_USER_WITH_SCHEMA = TestEntity\UserWithSchema::class;
     public const TEST_ENTITY_QUOTED           = TestEntity\Quoted::class;
+    public const TEST_ENTITY_GROUP            = TestEntity\Group::class;
 
     public function testGetAssociationTables()
     {
@@ -53,5 +54,19 @@ class ORMPurgerTest extends BaseTest
         $method->setAccessible(true);
         $tableName = $method->invokeArgs($purger, [$metadata, $platform]);
         $this->assertStringStartsWith('test_schema', $tableName);
+    }
+
+    public function testGetTableNameQuoted() : void
+    {
+        $em       = $this->getMockAnnotationReaderEntityManager();
+        $metadata = $em->getClassMetadata(self::TEST_ENTITY_GROUP);
+        $platform = $em->getConnection()->getDatabasePlatform();
+        $purger   = new ORMPurger($em);
+        $class    = new ReflectionClass(ORMPurger::class);
+        $method   = $class->getMethod('getTableName');
+        $method->setAccessible(true);
+        $tableName = $method->invokeArgs($purger, [$metadata, $platform]);
+        $this->assertStringStartsWith('"', $tableName);
+        $this->assertStringEndsWith('"', $tableName);
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Group.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Group.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class Group
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     *
+     * @var int|null
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(length=32)
+     * @ORM\Id
+     *
+     * @var string|null
+     */
+    private $code;
+
+    public function setId($id) : void
+    {
+        $this->id = $id;
+    }
+
+    public function getId() : ?int
+    {
+        return $this->id;
+    }
+
+    public function setCode($code) : void
+    {
+        $this->code = $code;
+    }
+
+    public function getCode() : ?string
+    {
+        return $this->code;
+    }
+}


### PR DESCRIPTION
Technically a duplicate of PR #292 but with tests included.

Essentially, purging the database in DELETE mode prior to fixture load fails if any fixture entities use tables names with reserved words (e.g. 'User' in Postgres, or in the test case 'Group' in sqlite). The change makes ORMPurger->getTableName() use the same method as AbstractPlatform::getTruncateTableSQL() uses to get the table name (quoted as necessary).

Test case uses sqlite reserved word 'Group' as an example and checks returned table name is quoted correctly.

Closes #292 