### PR TITLE
Expect a table name that uses schema emulation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "doctrine/orm": "^2.5.4",
+        "doctrine/orm": "^2.7.0",
         "doctrine/dbal": "^2.5.4",
         "phpunit/phpunit": "^7.0",
         "alcaeus/mongo-php-adapter": "^1.1",

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -31,7 +31,7 @@ class ORMPurgerTest extends BaseTest
         $method = $class->getMethod('getAssociationTables');
         $method->setAccessible(true);
         $associationTables = $method->invokeArgs($purger, [[$metadata], $platform]);
-        $this->assertEquals($associationTables[0], 'readers.author_reader');
+        $this->assertEquals($associationTables[0], 'readers__author_reader');
     }
 
     public function testGetAssociationTablesQuoted()


### PR DESCRIPTION
We use SQLite in tests, and that platform does not support schemas.