### PR TITLE
Fix doctrine/data-fixtures PR#334

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use function array_reverse;
 use function array_search;
 use function count;
-use function implode;
 use function is_callable;
 use function method_exists;
 use function preg_match;
@@ -152,7 +151,7 @@ class ORMPurger implements PurgerInterface
             }
 
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
-                $connection->executeUpdate('DELETE FROM ' . $tbl);
+                $connection->executeUpdate($this->getDeleteFromTableSQL($tbl, $platform));
             } else {
                 $connection->executeUpdate($platform->getTruncateTableSQL($tbl, true));
             }
@@ -240,23 +239,13 @@ class ORMPurger implements PurgerInterface
         return $associationTables;
     }
 
-    /**
-     * @param ClassMetadata    $class
-     * @param AbstractPlatform $platform
-     *
-     * @return string
-     */
-    private function getTableName($class, $platform)
+    private function getTableName(ClassMetadata $class, AbstractPlatform $platform) : string
     {
-        if (method_exists($class, 'getSchemaName')) {
-            $identifier[] = $class->getSchemaName();
-        } elseif (isset($class->table['schema'])) {
-            $identifier[] = $class->table['schema'];
+        if (isset($class->table['schema']) && ! method_exists($class, 'getSchemaName')) {
+            return $class->table['schema'] . '.' . $this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
         }
 
-        $identifier[] = $class->getTableName();
-
-        return (new Identifier(implode('.', $identifier)))->getQuotedName($platform);
+        return $this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
     }
 
     /**
@@ -273,5 +262,12 @@ class ORMPurger implements PurgerInterface
         }
 
         return $this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);
+    }
+
+    private function getDeleteFromTableSQL(string $tableName, AbstractPlatform $platform) : string
+    {
+        $tableIdentifier = new Identifier($tableName);
+
+        return 'DELETE FROM ' . $tableIdentifier->getQuotedName($platform);
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="group",schema="test_schema")
+ */
+class GroupWithSchema
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     *
+     * @var int|null
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(length=32)
+     * @ORM\Id
+     *
+     * @var string|null
+     */
+    private $code;
+
+    public function setId($id) : void
+    {
+        $this->id = $id;
+    }
+
+    public function getId() : ?int
+    {
+        return $this->id;
+    }
+
+    public function setCode($code) : void
+    {
+        $this->code = $code;
+    }
+
+    public function getCode() : ?string
+    {
+        return $this->code;
+    }
+}


### PR DESCRIPTION
PR #334  broke existing code by adding quotes in the middle of table names that used schemas in SQLite - as reported in #338 . 

I've reworked it into a cleaner function that mimics SchemaTool in doctrine/orm. Tests included and pass locally; I've also setup and run a simple test project locally using schema and non-schema entities without issue.