### PR TITLE
Fix DependentFixtureInterface return documentation

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
@@ -13,7 +13,7 @@ interface DependentFixtureInterface
      * This method must return an array of fixtures classes
      * on which the implementing class depends on
      *
-     * @return class-string[]
+     * @psalm-return class-string[]
      */
     public function getDependencies();
 }


### PR DESCRIPTION
This issue is causing problems for static analysis on projects using this library. Perhaps it was merely forgotten when introducing pslam?