### PR TITLE
Allow Custom ORMPurger

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Common\DataFixtures\Executor;
 
 use Doctrine\Common\DataFixtures\Event\Listener\ORMReferenceListener;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Common\DataFixtures\Purger\ORMPurgerInterface;
 use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -22,7 +22,7 @@ class ORMExecutor extends AbstractExecutor
      *
      * @param EntityManagerInterface $em EntityManagerInterface instance used for persistence.
      */
-    public function __construct(EntityManagerInterface $em, ?ORMPurger $purger = null)
+    public function __construct(EntityManagerInterface $em, ?ORMPurgerInterface $purger = null)
     {
         $this->em = $em;
         if ($purger !== null) {

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -20,7 +20,7 @@ use function preg_match;
 /**
  * Class responsible for purging databases of data before reloading data fixtures.
  */
-class ORMPurger implements PurgerInterface
+class ORMPurger implements PurgerInterface, ORMPurgerInterface
 {
     public const PURGE_MODE_DELETE   = 1;
     public const PURGE_MODE_TRUNCATE = 2;
@@ -76,9 +76,7 @@ class ORMPurger implements PurgerInterface
         return $this->purgeMode;
     }
 
-    /**
-     * Set the EntityManagerInterface instance this purger instance should use.
-     */
+    /** @inheritDoc */
     public function setEntityManager(EntityManagerInterface $em)
     {
         $this->em = $em;

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurgerInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurgerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\DataFixtures\Purger;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * ORMPurgerInterface
+ */
+interface ORMPurgerInterface
+{
+    /**
+     * Set the EntityManagerInterface instance this purger instance should use.
+     *
+     * @return void
+     */
+    public function setEntityManager(EntityManagerInterface $em);
+}

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurgerInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurgerInterface.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 /**
  * ORMPurgerInterface
  */
-interface ORMPurgerInterface
+interface ORMPurgerInterface extends PurgerInterface
 {
     /**
      * Set the EntityManagerInterface instance this purger instance should use.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -39,6 +39,7 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
         <exclude-pattern>lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/Common/DataFixtures/FixtureInterface.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/Common/DataFixtures/Purger/ORMPurgerInterface.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/Common/DataFixtures/Purger/PurgerInterface.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/Common/DataFixtures/OrderedFixtureInterface.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/Common/DataFixtures/SharedFixtureInterface.php</exclude-pattern>


### PR DESCRIPTION
https://github.com/doctrine/DoctrineFixturesBundle/pull/307 on Bundle-side allowed to create custom Purger, however an instance of ORMPurger is needed.
This PR allows a new ORMPurgerInterface to be used instead.