### PR TITLE
Allows both doctrine/common 3.x & doctrine/persistence 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "doctrine/common": "^2.11",
-        "doctrine/persistence": "^1.3.3"
+        "doctrine/common": "^2.13|^3.0",
+        "doctrine/persistence": "^1.3.3|^2.0"
     },
     "conflict": {
         "doctrine/phpcr-odm": "<1.3.0"

--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Common\DataFixtures;
 
-use Doctrine\Common\Util\ClassUtils;
-use Doctrine\Common\Version;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
@@ -31,10 +29,6 @@ class ProxyReferenceRepository extends ReferenceRepository
      */
     protected function getRealClass($className)
     {
-        if (Version::compare('2.2.0') <= 0) {
-            return ClassUtils::getRealClass($className);
-        }
-
         if (substr($className, -5) === 'Proxy') {
             return substr($className, 0, -5);
         }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues |

#### Summary

- Allows doctrine/common 3.x & doctrine/persistence 2.x
- Bumps 2.x of doctrine/common to 2.13 [because of release notes](https://github.com/doctrine/common/releases/tag/3.0.0)

Thoughts?