### PR TITLE
Allow using ODM 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,23 +22,19 @@
         "doctrine/phpcr-odm": "<1.3.0"
     },
     "require-dev": {
-        "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/coding-standard": "^6.0",
         "doctrine/dbal": "^2.5.4",
-        "doctrine/mongodb-odm": "^1.3.0",
+        "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
         "doctrine/orm": "^2.7.0",
         "phpunit/phpunit": "^7.0"
     },
     "suggest": {
-        "alcaeus/mongo-php-adapter": "For using MongoDB ODM with PHP 7",
+        "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
         "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
         "doctrine/orm": "For loading ORM fixtures",
         "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
     },
     "config": {
-        "platform": {
-            "ext-mongo": "1.6.16"
-        },
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
See https://github.com/doctrine/data-fixtures/pull/349#issuecomment-683468881.

Suggesting this for a patch release as it involves no code changes and only loosens a require-dev constraint to allow **testing** against ODM 2.0.