### PR TITLE
Upgrade the Doctrine Coding Standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "doctrine/coding-standard": "^6.0",
+        "doctrine/coding-standard": "^8.2",
         "doctrine/dbal": "^2.5.4",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
         "doctrine/orm": "^2.7.0",

--- a/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/DependentFixtureInterface.php
@@ -13,7 +13,7 @@ interface DependentFixtureInterface
      * This method must return an array of fixtures classes
      * on which the implementing class depends on
      *
-     * @return class-string[]
+     * @psalm-return array<class-string<FixtureInterface>>
      */
     public function getDependencies();
 }

--- a/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
@@ -11,6 +11,7 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Common\DataFixtures\SharedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Exception;
+
 use function get_class;
 use function interface_exists;
 use function sprintf;
@@ -106,12 +107,15 @@ abstract class AbstractExecutor
             if ($fixture instanceof OrderedFixtureInterface) {
                 $prefix = sprintf('[%d] ', $fixture->getOrder());
             }
+
             $this->log('loading ' . $prefix . get_class($fixture));
         }
+
         // additionally pass the instance of reference repository to shared fixtures
         if ($fixture instanceof SharedFixtureInterface) {
             $fixture->setReferenceRepository($this->referenceRepository);
         }
+
         $fixture->load($manager);
         $manager->clear();
     }
@@ -126,9 +130,11 @@ abstract class AbstractExecutor
         if ($this->purger === null) {
             throw new Exception('Doctrine\Common\DataFixtures\Purger\PurgerInterface instance is required if you want to purge the database before loading your data fixtures.');
         }
+
         if ($this->logger) {
             $this->log('purging database');
         }
+
         $this->purger->purge();
     }
 

--- a/lib/Doctrine/Common/DataFixtures/Executor/MongoDBExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/MongoDBExecutor.php
@@ -26,6 +26,7 @@ class MongoDBExecutor extends AbstractExecutor
             $this->purger = $purger;
             $this->purger->setDocumentManager($dm);
         }
+
         parent::__construct($dm);
         $this->listener = new MongoDBReferenceListener($this->referenceRepository);
         $dm->getEventManager()->addEventSubscriber($this->listener);
@@ -60,6 +61,7 @@ class MongoDBExecutor extends AbstractExecutor
         if ($append === false) {
             $this->purge();
         }
+
         foreach ($fixtures as $fixture) {
             $this->load($this->dm, $fixture);
         }

--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -29,6 +29,7 @@ class ORMExecutor extends AbstractExecutor
             $this->purger = $purger;
             $this->purger->setEntityManager($em);
         }
+
         parent::__construct($em);
         $this->listener = new ORMReferenceListener($this->referenceRepository);
         $em->getEventManager()->addEventSubscriber($this->listener);
@@ -65,6 +66,7 @@ class ORMExecutor extends AbstractExecutor
             if ($append === false) {
                 $executor->purge();
             }
+
             foreach ($fixtures as $fixture) {
                 $executor->load($em, $fixture);
             }

--- a/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
@@ -6,6 +6,7 @@ namespace Doctrine\Common\DataFixtures\Executor;
 
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
 use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+
 use function method_exists;
 
 /**

--- a/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/PHPCRExecutor.php
@@ -34,6 +34,9 @@ class PHPCRExecutor extends AbstractExecutor
         $this->setPurger($purger);
     }
 
+    /**
+     * @return DocumentManagerInterface
+     */
     public function getObjectManager()
     {
         return $this->dm;

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Common\DataFixtures;
 
 use Doctrine\Persistence\ObjectManager;
+
 use function interface_exists;
 
 /**

--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -13,6 +13,7 @@ use RecursiveIteratorIterator;
 use ReflectionClass;
 use RuntimeException;
 use SplFileInfo;
+
 use function array_keys;
 use function array_merge;
 use function asort;

--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -40,14 +40,14 @@ class Loader
     /**
      * Array of fixture object instances to execute.
      *
-     * @var array
+     * @psalm-var array<class-string<FixtureInterface>, FixtureInterface>
      */
     private $fixtures = [];
 
     /**
      * Array of ordered fixture object instances.
      *
-     * @var array
+     * @psalm-var array<class-string<OrderedFixtureInterface>, OrderedFixtureInterface>
      */
     private $orderedFixtures = [];
 
@@ -207,6 +207,8 @@ class Loader
      * class.
      *
      * @return bool
+     *
+     * @psalm-param class-string<object> $className
      */
     public function isTransient($className)
     {
@@ -235,14 +237,12 @@ class Loader
     /**
      * Orders fixtures by number
      *
-     * @return void
-     *
      * @todo maybe there is a better way to handle reordering
      */
-    private function orderFixturesByNumber()
+    private function orderFixturesByNumber(): void
     {
         $this->orderedFixtures = $this->fixtures;
-        usort($this->orderedFixtures, static function ($a, $b) {
+        usort($this->orderedFixtures, static function (FixtureInterface $a, FixtureInterface $b): int {
             if ($a instanceof OrderedFixtureInterface && $b instanceof OrderedFixtureInterface) {
                 if ($a->getOrder() === $b->getOrder()) {
                     return 0;
@@ -270,6 +270,7 @@ class Loader
      */
     private function orderFixturesByDependencies()
     {
+        /** @psalm-var array<class-string<DependentFixtureInterface>, int> */
         $sequenceForClasses = [];
 
         // If fixtures were already ordered by number then we need
@@ -363,7 +364,10 @@ class Loader
         $this->orderedFixtures = array_merge($this->orderedFixtures, $orderedFixtures);
     }
 
-    private function validateDependencies($dependenciesClasses)
+    /**
+     * @psalm-param iterable<class-string> $dependenciesClasses
+     */
+    private function validateDependencies(iterable $dependenciesClasses): bool
     {
         $loadedFixtureClasses = array_keys($this->fixtures);
 
@@ -376,7 +380,12 @@ class Loader
         return true;
     }
 
-    private function getUnsequencedClasses($sequences, $classes = null)
+    /**
+     * @psalm-param array<class-string<DependentFixtureInterface>, int> $sequences
+     * @psalm-param iterable<class-string<FixtureInterface>>|null       $classes
+     * @psalm-return array<class-string<FixtureInterface>>
+     */
+    private function getUnsequencedClasses(array $sequences, ?iterable $classes = null): array
     {
         $unsequencedClasses = [];
 
@@ -398,11 +407,11 @@ class Loader
     /**
      * Load fixtures from files contained in iterator.
      *
-     * @param Iterator $iterator Iterator over files from which fixtures should be loaded.
-     *
-     * @return array $fixtures Array of loaded fixture object instances.
+     * @psalm-param Iterator<SplFileInfo> $iterator Iterator over files from
+     *                                              which fixtures should be loaded.
+     * @psalm-return list<FixtureInterface> $fixtures Array of loaded fixture object instances.
      */
-    private function loadFromIterator(Iterator $iterator)
+    private function loadFromIterator(Iterator $iterator): array
     {
         $includedFiles = [];
         foreach ($iterator as $file) {

--- a/lib/Doctrine/Common/DataFixtures/Purger/MongoDBPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/MongoDBPurger.php
@@ -53,6 +53,7 @@ class MongoDBPurger implements PurgerInterface
 
             $this->dm->getDocumentCollection($metadata->name)->drop();
         }
+
         $this->dm->getSchemaManager()->ensureIndexes();
     }
 }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -192,7 +192,7 @@ class ORMPurger implements PurgerInterface
                 }
 
                 /** @var ClassMetadata $targetClass */
-                $targetClass = $em->getClassMetadata($assoc['targetEntity']);
+                $targetClass     = $em->getClassMetadata($assoc['targetEntity']);
                 $targetClassName = $targetClass->getName();
 
                 if (! $sorter->hasNode($targetClassName)) {

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -252,14 +252,13 @@ class ORMPurger implements PurgerInterface
     }
 
     /**
-     * @param array            $association
-     * @param ClassMetadata    $class
-     * @param AbstractPlatform $platform
-     *
-     * @return string
+     * @param mixed[] $assoc
      */
-    private function getJoinTableName($assoc, $class, $platform)
-    {
+    private function getJoinTableName(
+        array $assoc,
+        ClassMetadata $class,
+        AbstractPlatform $platform
+    ): string {
         if (isset($assoc['joinTable']['schema']) && ! method_exists($class, 'getSchemaName')) {
             return $assoc['joinTable']['schema'] . '.' . $this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);
         }

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+
 use function array_reverse;
 use function array_search;
 use function count;
@@ -118,7 +119,8 @@ class ORMPurger implements PurgerInterface
         for ($i = count($commitOrder) - 1; $i >= 0; --$i) {
             $class = $commitOrder[$i];
 
-            if ((isset($class->isEmbeddedClass) && $class->isEmbeddedClass) ||
+            if (
+                (isset($class->isEmbeddedClass) && $class->isEmbeddedClass) ||
                 $class->isMappedSuperclass ||
                 ($class->isInheritanceTypeSingleTable() && $class->name !== $class->rootEntityName)
             ) {
@@ -190,7 +192,7 @@ class ORMPurger implements PurgerInterface
                 }
 
                 /** @var ClassMetadata $targetClass */
-                $targetClass     = $em->getClassMetadata($assoc['targetEntity']);
+                $targetClass = $em->getClassMetadata($assoc['targetEntity']);
                 $targetClassName = $targetClass->getName();
 
                 if (! $sorter->hasNode($targetClassName)) {
@@ -239,7 +241,7 @@ class ORMPurger implements PurgerInterface
         return $associationTables;
     }
 
-    private function getTableName(ClassMetadata $class, AbstractPlatform $platform) : string
+    private function getTableName(ClassMetadata $class, AbstractPlatform $platform): string
     {
         if (isset($class->table['schema']) && ! method_exists($class, 'getSchemaName')) {
             return $class->table['schema'] . '.' . $this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
@@ -264,7 +266,7 @@ class ORMPurger implements PurgerInterface
         return $this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);
     }
 
-    private function getDeleteFromTableSQL(string $tableName, AbstractPlatform $platform) : string
+    private function getDeleteFromTableSQL(string $tableName, AbstractPlatform $platform): string
     {
         $tableIdentifier = new Identifier($tableName);
 

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 
 use function array_reverse;
 use function array_search;
+use function assert;
 use function count;
 use function is_callable;
 use function method_exists;
@@ -191,8 +192,8 @@ class ORMPurger implements PurgerInterface
                     continue;
                 }
 
-                /** @var ClassMetadata $targetClass */
-                $targetClass     = $em->getClassMetadata($assoc['targetEntity']);
+                $targetClass = $em->getClassMetadata($assoc['targetEntity']);
+                assert($targetClass instanceof ClassMetadata);
                 $targetClassName = $targetClass->getName();
 
                 if (! $sorter->hasNode($targetClassName)) {

--- a/lib/Doctrine/Common/DataFixtures/Purger/PHPCRPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/PHPCRPurger.php
@@ -13,7 +13,7 @@ use PHPCR\Util\NodeHelper;
  */
 class PHPCRPurger implements PurgerInterface
 {
-    /** @var DocumentManagerInterface */
+    /** @var DocumentManagerInterface|null */
     private $dm;
 
     public function __construct(?DocumentManagerInterface $dm = null)
@@ -26,6 +26,9 @@ class PHPCRPurger implements PurgerInterface
         $this->dm = $dm;
     }
 
+    /**
+     * @return DocumentManagerInterface|null
+     */
     public function getObjectManager()
     {
         return $this->dm;

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -199,6 +199,8 @@ class ReferenceRepository
      * Checks if reference has identity stored
      *
      * @param string $name
+     *
+     * @return bool
      */
     public function hasIdentity($name)
     {

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Doctrine\ODM\PHPCR\DocumentManager as PhpcrDocumentManager;
 use Doctrine\Persistence\ObjectManager;
 use OutOfBoundsException;
+
 use function array_key_exists;
 use function array_keys;
 use function get_class;

--- a/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
+++ b/lib/Doctrine/Common/DataFixtures/Sorter/TopologicalSorter.php
@@ -7,6 +7,7 @@ namespace Doctrine\Common\DataFixtures\Sorter;
 use Doctrine\Common\DataFixtures\Exception\CircularReferenceException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use RuntimeException;
+
 use function get_class;
 use function sprintf;
 
@@ -166,6 +167,7 @@ class TopologicalSorter
                             )
                         );
                     }
+
                     break;
                 case Vertex::NOT_VISITED:
                     $this->visit($childDefinition);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,9 +14,9 @@
 
     <rule ref="Doctrine">
         <!-- Traversable type hints often end up as mixed[], so we skip them for now -->
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
 
         <!-- Will cause BC breaks to method signatures - disabled for now -->
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,8 +19,15 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
 
         <!-- Will cause BC breaks to method signatures - disabled for now -->
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint" />
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
+    </rule>
+
+    <!-- Property type hints are only available in PHP 7.4+ -->
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+        </properties>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
@@ -21,7 +21,7 @@ use function array_shift;
  */
 class DependentFixtureTest extends BaseTest
 {
-    public function testOrderFixturesByDependenciesOrderClassesWithASingleParent()
+    public function testOrderFixturesByDependenciesOrderClassesWithASingleParent(): void
     {
         $loader = new Loader();
         $loader->addFixture(new DependentFixture3());
@@ -38,7 +38,7 @@ class DependentFixtureTest extends BaseTest
         $this->assertInstanceOf(DependentFixture3::class, array_shift($orderedFixtures));
     }
 
-    public function testOrderFixturesByDependenciesOrderClassesWithAMultipleParents()
+    public function testOrderFixturesByDependenciesOrderClassesWithAMultipleParents(): void
     {
         $loader = new Loader();
 
@@ -83,7 +83,7 @@ class DependentFixtureTest extends BaseTest
         $this->assertGreaterThan($countryFixtureOrder, $addressFixtureOrder);
     }
 
-    public function testOrderFixturesByDependenciesCircularReferencesMakeMethodThrowCircularReferenceException()
+    public function testOrderFixturesByDependenciesCircularReferencesMakeMethodThrowCircularReferenceException(): void
     {
         $loader = new Loader();
 
@@ -96,7 +96,7 @@ class DependentFixtureTest extends BaseTest
         $loader->getFixtures();
     }
 
-    public function testOrderFixturesByDependenciesFixturesCantHaveItselfAsParent()
+    public function testOrderFixturesByDependenciesFixturesCantHaveItselfAsParent(): void
     {
         $loader = new Loader();
 
@@ -107,7 +107,7 @@ class DependentFixtureTest extends BaseTest
         $loader->getFixtures();
     }
 
-    public function testInCaseThereAreFixturesOrderedByNumberAndByDependenciesBothOrdersAreExecuted()
+    public function testInCaseThereAreFixturesOrderedByNumberAndByDependenciesBothOrdersAreExecuted(): void
     {
         $loader = new Loader();
         $loader->addFixture(new OrderedByNumberFixture1());
@@ -130,7 +130,7 @@ class DependentFixtureTest extends BaseTest
         $this->assertInstanceOf(DependentFixture3::class, array_shift($orderedFixtures));
     }
 
-    public function testInCaseAFixtureHasAnUnexistentDependencyOrIfItWasntLoadedThrowsException()
+    public function testInCaseAFixtureHasAnUnexistentDependencyOrIfItWasntLoadedThrowsException(): void
     {
         $loader = new Loader();
         $loader->addFixture(new FixtureWithUnexistentDependency());
@@ -140,7 +140,7 @@ class DependentFixtureTest extends BaseTest
         $loader->getFixtures();
     }
 
-    public function testInCaseGetFixturesReturnsDifferentResultsEachTime()
+    public function testInCaseGetFixturesReturnsDifferentResultsEachTime(): void
     {
         $loader = new Loader();
         $loader->addFixture(new DependentFixture1());
@@ -158,11 +158,14 @@ class DependentFixtureTest extends BaseTest
 
 class DependentFixture1 implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [BaseParentFixture1::class];
     }
@@ -170,11 +173,14 @@ class DependentFixture1 implements FixtureInterface, DependentFixtureInterface
 
 class DependentFixture2 implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [DependentFixture1::class];
     }
@@ -182,11 +188,14 @@ class DependentFixture2 implements FixtureInterface, DependentFixtureInterface
 
 class DependentFixture3 implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [DependentFixture2::class];
     }
@@ -194,18 +203,21 @@ class DependentFixture3 implements FixtureInterface, DependentFixtureInterface
 
 class BaseParentFixture1 implements FixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 }
 
 class CountryFixture implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [BaseParentFixture1::class];
     }
@@ -213,11 +225,14 @@ class CountryFixture implements FixtureInterface, DependentFixtureInterface
 
 class StateFixture implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [
             BaseParentFixture1::class,
@@ -228,11 +243,14 @@ class StateFixture implements FixtureInterface, DependentFixtureInterface
 
 class AddressFixture implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [
             BaseParentFixture1::class,
@@ -244,11 +262,14 @@ class AddressFixture implements FixtureInterface, DependentFixtureInterface
 
 class ContactMethodFixture implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [BaseParentFixture1::class];
     }
@@ -256,11 +277,14 @@ class ContactMethodFixture implements FixtureInterface, DependentFixtureInterfac
 
 class ContactFixture implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [
             AddressFixture::class,
@@ -271,11 +295,14 @@ class ContactFixture implements FixtureInterface, DependentFixtureInterface
 
 class CircularReferenceFixture implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [CircularReferenceFixture3::class];
     }
@@ -283,11 +310,14 @@ class CircularReferenceFixture implements FixtureInterface, DependentFixtureInte
 
 class CircularReferenceFixture2 implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [CircularReferenceFixture::class];
     }
@@ -295,11 +325,14 @@ class CircularReferenceFixture2 implements FixtureInterface, DependentFixtureInt
 
 class CircularReferenceFixture3 implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [CircularReferenceFixture2::class];
     }
@@ -307,11 +340,14 @@ class CircularReferenceFixture3 implements FixtureInterface, DependentFixtureInt
 
 class FixtureWithItselfAsParent implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [self::class];
     }
@@ -319,11 +355,14 @@ class FixtureWithItselfAsParent implements FixtureInterface, DependentFixtureInt
 
 class FixtureWithUnexistentDependency implements FixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return ['UnexistentDependency'];
     }
@@ -331,16 +370,19 @@ class FixtureWithUnexistentDependency implements FixtureInterface, DependentFixt
 
 class FixtureImplementingBothOrderingInterfaces implements FixtureInterface, OrderedFixtureInterface, DependentFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }
 
-    public function getDependencies()
+    /**
+     * {@inheritDoc}
+     */
+    public function getDependencies(): array
     {
         return [FixtureWithItselfAsParent::class];
     }
@@ -348,11 +390,11 @@ class FixtureImplementingBothOrderingInterfaces implements FixtureInterface, Ord
 
 class OrderedByNumberFixture1 implements FixtureInterface, OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 1;
     }
@@ -360,11 +402,11 @@ class OrderedByNumberFixture1 implements FixtureInterface, OrderedFixtureInterfa
 
 class OrderedByNumberFixture2 implements FixtureInterface, OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }
@@ -372,11 +414,11 @@ class OrderedByNumberFixture2 implements FixtureInterface, OrderedFixtureInterfa
 
 class OrderedByNumberFixture3 implements FixtureInterface, OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 10;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/DependentFixtureTest.php
@@ -12,6 +12,7 @@ use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use InvalidArgumentException;
 use RuntimeException;
+
 use function array_search;
 use function array_shift;
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorSharedFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorSharedFixtureTest.php
@@ -10,6 +10,7 @@ use Doctrine\Common\DataFixtures\SharedFixtureInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Common\DataFixtures\TestEntity\Role;
 use Doctrine\Tests\Common\DataFixtures\TestEntity\User;
+
 use function extension_loaded;
 
 /**

--- a/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorSharedFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorSharedFixtureTest.php
@@ -21,7 +21,7 @@ class ORMExecutorSharedFixtureTest extends BaseTest
     public const TEST_ENTITY_ROLE = Role::class;
     public const TEST_ENTITY_USER = User::class;
 
-    public function testFixtureExecution()
+    public function testFixtureExecution(): void
     {
         $em       = $this->getMockAnnotationReaderEntityManager();
         $purger   = new ORMPurger();
@@ -40,7 +40,7 @@ class ORMExecutorSharedFixtureTest extends BaseTest
         $executor->execute([$fixture], true);
     }
 
-    public function testSharedFixtures()
+    public function testSharedFixtures(): void
     {
         if (! extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped('Missing pdo_sqlite extension.');
@@ -74,7 +74,7 @@ class ORMExecutorSharedFixtureTest extends BaseTest
         $this->assertEquals('admin@example.com', $userReference->getEmail());
     }
 
-    private function getMockFixture()
+    private function getMockFixture(): SharedFixtureInterface
     {
         return $this->createMock(SharedFixtureInterface::class);
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorTest.php
@@ -14,7 +14,7 @@ use Doctrine\Tests\Common\DataFixtures\BaseTest;
  */
 class ORMExecutorTest extends BaseTest
 {
-    public function testExecuteWithNoPurge()
+    public function testExecuteWithNoPurge(): void
     {
         $em     = $this->getMockSqliteEntityManager();
         $purger = $this->getMockPurger();
@@ -29,7 +29,7 @@ class ORMExecutorTest extends BaseTest
         $executor->execute([$fixture], true);
     }
 
-    public function testExecuteWithPurge()
+    public function testExecuteWithPurge(): void
     {
         $em     = $this->getMockSqliteEntityManager();
         $purger = $this->getMockPurger();
@@ -44,7 +44,7 @@ class ORMExecutorTest extends BaseTest
         $executor->execute([$fixture], false);
     }
 
-    public function testExecuteTransaction()
+    public function testExecuteTransaction(): void
     {
         $em       = $this->getMockSqliteEntityManager();
         $executor = new ORMExecutor($em);
@@ -55,12 +55,12 @@ class ORMExecutorTest extends BaseTest
         $executor->execute([$fixture], true);
     }
 
-    private function getMockFixture()
+    private function getMockFixture(): FixtureInterface
     {
         return $this->createMock(FixtureInterface::class);
     }
 
-    private function getMockPurger()
+    private function getMockPurger(): ORMPurger
     {
         return $this->createMock(ORMPurger::class);
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
@@ -12,6 +12,7 @@ use Doctrine\Tests\Common\DataFixtures\BaseTest;
 use Exception;
 use PHPUnit_Framework_MockObject_MockObject;
 use Throwable;
+
 use function class_exists;
 
 /**

--- a/tests/Doctrine/Tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
@@ -22,7 +22,7 @@ use function class_exists;
  */
 class PHPCRExecutorTest extends BaseTest
 {
-    public function testExecuteSingleFixtureWithNoPurge()
+    public function testExecuteSingleFixtureWithNoPurge(): void
     {
         $dm       = $this->getDocumentManager();
         $executor = new PHPCRExecutor($dm);
@@ -40,7 +40,7 @@ class PHPCRExecutorTest extends BaseTest
         $executor->execute([$fixture], true);
     }
 
-    public function testExecuteMultipleFixturesWithNoPurge()
+    public function testExecuteMultipleFixturesWithNoPurge(): void
     {
         $dm       = $this->getDocumentManager();
         $executor = new PHPCRExecutor($dm);
@@ -60,7 +60,7 @@ class PHPCRExecutorTest extends BaseTest
         $executor->execute([$fixture1, $fixture2], true);
     }
 
-    public function testExecuteFixtureWithPurge()
+    public function testExecuteFixtureWithPurge(): void
     {
         $dm       = $this->getDocumentManager();
         $purger   = $this->getPurger();
@@ -80,7 +80,7 @@ class PHPCRExecutorTest extends BaseTest
         $executor->execute([$fixture], false);
     }
 
-    public function testExecuteFixtureWithoutPurge()
+    public function testExecuteFixtureWithoutPurge(): void
     {
         $dm       = $this->getDocumentManager();
         $purger   = $this->getPurger();
@@ -100,7 +100,7 @@ class PHPCRExecutorTest extends BaseTest
         $executor->execute([$fixture], true);
     }
 
-    public function testFailedTransactionalStopsPurgingAndFixtureLoading()
+    public function testFailedTransactionalStopsPurgingAndFixtureLoading(): void
     {
         $dm        = $this->getDocumentManager();
         $purger    = $this->getPurger();

--- a/tests/Doctrine/Tests/Common/DataFixtures/FixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/FixtureTest.php
@@ -12,7 +12,7 @@ use Doctrine\Persistence\ObjectManager;
  */
 class FixtureTest extends BaseTest
 {
-    public function testFixtureInterface()
+    public function testFixtureInterface(): void
     {
         $em      = $this->createMock(ObjectManager::class);
         $fixture = new MyFixture2();
@@ -27,7 +27,7 @@ class MyFixture2 implements FixtureInterface
     /** @var bool */
     public $loaded = false;
 
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $this->loaded = true;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/LoaderTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/LoaderTest.php
@@ -15,7 +15,7 @@ use TestFixtures\NotAFixture;
  */
 class LoaderTest extends BaseTest
 {
-    public function testLoadFromDirectory()
+    public function testLoadFromDirectory(): void
     {
         $loader = new Loader();
         $loader->addFixture($this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock1')->getMock());
@@ -30,7 +30,7 @@ class LoaderTest extends BaseTest
         $this->assertFalse($loader->isTransient(MyFixture1::class));
     }
 
-    public function testLoadFromFile()
+    public function testLoadFromFile(): void
     {
         $loader = new Loader();
         $loader->addFixture($this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock1')->getMock());
@@ -49,7 +49,7 @@ class LoaderTest extends BaseTest
         $this->assertFalse($loader->isTransient(MyFixture1::class));
     }
 
-    public function testGetFixture()
+    public function testGetFixture(): void
     {
         $loader = new Loader();
         $loader->loadFromFile(__DIR__ . '/TestFixtures/MyFixture1.php');

--- a/tests/Doctrine/Tests/Common/DataFixtures/OrderedFixtureTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/OrderedFixtureTest.php
@@ -14,7 +14,7 @@ use Doctrine\Persistence\ObjectManager;
  */
 class OrderedFixtureTest extends BaseTest
 {
-    public function testFixtureOrder()
+    public function testFixtureOrder(): void
     {
         $loader = new Loader();
         $loader->addFixture(new OrderedFixture1());
@@ -34,11 +34,11 @@ class OrderedFixtureTest extends BaseTest
 
 class OrderedFixture1 implements FixtureInterface, OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 5;
     }
@@ -46,11 +46,11 @@ class OrderedFixture1 implements FixtureInterface, OrderedFixtureInterface
 
 class OrderedFixture2 implements FixtureInterface, OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 2;
     }
@@ -58,11 +58,11 @@ class OrderedFixture2 implements FixtureInterface, OrderedFixtureInterface
 
 class OrderedFixture3 implements FixtureInterface, OrderedFixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 
-    public function getOrder()
+    public function getOrder(): int
     {
         return 8;
     }
@@ -70,7 +70,7 @@ class OrderedFixture3 implements FixtureInterface, OrderedFixtureInterface
 
 class BaseFixture1 implements FixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
@@ -33,7 +33,7 @@ class ProxyReferenceRepositoryTest extends BaseTest
         Type::addType('uuid', UuidType::class);
     }
 
-    public function testReferenceEntry()
+    public function testReferenceEntry(): void
     {
         $em   = $this->getMockAnnotationReaderEntityManager();
         $role = new TestEntity\Role();
@@ -51,7 +51,7 @@ class ProxyReferenceRepositoryTest extends BaseTest
         $this->assertInstanceOf(self::TEST_ENTITY_ROLE, $references['test']);
     }
 
-    public function testReferenceIdentityPopulation()
+    public function testReferenceIdentityPopulation(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = $this->getMockBuilder(ProxyReferenceRepository::class)
@@ -81,7 +81,7 @@ class ProxyReferenceRepositoryTest extends BaseTest
         $roleFixture->load($em);
     }
 
-    public function testReferenceReconstruction()
+    public function testReferenceReconstruction(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ProxyReferenceRepository($em);
@@ -158,7 +158,7 @@ class ProxyReferenceRepositoryTest extends BaseTest
         );
     }
 
-    public function testReferenceMultipleEntries()
+    public function testReferenceMultipleEntries(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ProxyReferenceRepository($em);

--- a/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
@@ -22,7 +22,7 @@ class ProxyReferenceRepositoryTest extends BaseTest
     public const TEST_ENTITY_ROLE = Role::class;
     public const TEST_ENTITY_LINK = Link::class;
 
-    public static function setUpBeforeClass() : void
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -129,7 +129,7 @@ class ProxyReferenceRepositoryTest extends BaseTest
         $this->assertInstanceOf(Proxy::class, $ref);
     }
 
-    public function testReconstructionOfCustomTypedId() : void
+    public function testReconstructionOfCustomTypedId(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ProxyReferenceRepository($em);

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -23,7 +23,7 @@ class MongoDBPurgerTest extends BaseTest
 {
     public const TEST_DOCUMENT_ROLE = Role::class;
 
-    private function getDocumentManager()
+    private function getDocumentManager(): DocumentManager
     {
         if (! class_exists('Doctrine\ODM\MongoDB\DocumentManager')) {
             $this->markTestSkipped('Missing doctrine/mongodb-odm');
@@ -47,12 +47,12 @@ class MongoDBPurgerTest extends BaseTest
         return $dm;
     }
 
-    private function getPurger()
+    private function getPurger(): MongoDBPurger
     {
         return new MongoDBPurger($this->getDocumentManager());
     }
 
-    public function testPurgeKeepsIndices()
+    public function testPurgeKeepsIndices(): void
     {
         $purger = $this->getPurger();
         $dm     = $purger->getObjectManager();
@@ -74,7 +74,9 @@ class MongoDBPurgerTest extends BaseTest
         $this->assertIndexCount(2, $collection);
     }
 
-    /** @var Collection|MongoCollection $collection */
+    /**
+     * @param Collection|MongoCollection $collection
+     */
     private function assertIndexCount(int $expectedCount, $collection): void
     {
         if ($collection instanceof Collection) {

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -14,6 +14,7 @@ use Doctrine\Tests\Common\DataFixtures\TestDocument\Role;
 use MongoCollection;
 use MongoDB\Collection;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
+
 use function class_exists;
 use function dirname;
 use function method_exists;
@@ -74,7 +75,7 @@ class MongoDBPurgerTest extends BaseTest
     }
 
     /** @var Collection|MongoCollection $collection */
-    private function assertIndexCount(int $expectedCount, $collection) : void
+    private function assertIndexCount(int $expectedCount, $collection): void
     {
         if ($collection instanceof Collection) {
             $indexes = $collection->listIndexes();
@@ -85,7 +86,7 @@ class MongoDBPurgerTest extends BaseTest
         $this->assertCount($expectedCount, $indexes);
     }
 
-    private function skipIfMongoDBUnavailable(DocumentManager $documentManager) : void
+    private function skipIfMongoDBUnavailable(DocumentManager $documentManager): void
     {
         if (method_exists($documentManager, 'getClient')) {
             try {

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\ExcludedEntity;
 use Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\IncludedEntity;
+
 use function count;
 use function extension_loaded;
 use function method_exists;
@@ -115,9 +116,9 @@ class ORMPurgerExcludeTest extends BaseTest
         $this->executeTestPurge(null, ['ExcludedEntity'], null);
     }
 
-    public function testPurgeExcludeUsingFilterCallable() : void
+    public function testPurgeExcludeUsingFilterCallable(): void
     {
-        $this->executeTestPurge(null, [], static function (string $table) : bool {
+        $this->executeTestPurge(null, [], static function (string $table): bool {
             return (bool) preg_match('~^(?!ExcludedEntity)~', $table);
         });
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -66,7 +66,7 @@ class ORMPurgerExcludeTest extends BaseTest
      * @param string|null $expression
      * @param array       $list
      */
-    public function executeTestPurge($expression, array $list, ?callable $filter = null)
+    public function executeTestPurge($expression, array $list, ?callable $filter = null): void
     {
         $em                 = $this->loadTestData();
         $excludedRepository = $em->getRepository(self::TEST_ENTITY_EXCLUDED);
@@ -103,7 +103,7 @@ class ORMPurgerExcludeTest extends BaseTest
     /**
      * Test for purge exclusion usig dbal filter expression regexp.
      */
-    public function testPurgeExcludeUsingFilterExpression()
+    public function testPurgeExcludeUsingFilterExpression(): void
     {
         $this->executeTestPurge('~^(?!ExcludedEntity)~', [], null);
     }
@@ -111,7 +111,7 @@ class ORMPurgerExcludeTest extends BaseTest
     /**
      * Test for purge exclusion usig explicit exclution list.
      */
-    public function testPurgeExcludeUsingList()
+    public function testPurgeExcludeUsingList(): void
     {
         $this->executeTestPurge(null, ['ExcludedEntity'], null);
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -18,7 +18,7 @@ class ORMPurgerTest extends BaseTest
     public const TEST_ENTITY_GROUP             = TestEntity\Group::class;
     public const TEST_ENTITY_GROUP_WITH_SCHEMA = TestEntity\GroupWithSchema::class;
 
-    public function testGetAssociationTables()
+    public function testGetAssociationTables(): void
     {
         $em       = $this->getMockAnnotationReaderEntityManager();
         $metadata = $em->getClassMetadata(self::TEST_ENTITY_USER);
@@ -31,7 +31,7 @@ class ORMPurgerTest extends BaseTest
         $this->assertEquals($associationTables[0], 'readers__author_reader');
     }
 
-    public function testGetAssociationTablesQuoted()
+    public function testGetAssociationTablesQuoted(): void
     {
         $em       = $this->getMockAnnotationReaderEntityManager();
         $metadata = $em->getClassMetadata(self::TEST_ENTITY_QUOTED);
@@ -44,7 +44,7 @@ class ORMPurgerTest extends BaseTest
         $this->assertEquals($associationTables[0], '"INSERT"');
     }
 
-    public function testTableNameWithSchema()
+    public function testTableNameWithSchema(): void
     {
         $em       = $this->getMockAnnotationReaderEntityManager();
         $metadata = $em->getClassMetadata(self::TEST_ENTITY_USER_WITH_SCHEMA);

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -57,7 +57,7 @@ class ORMPurgerTest extends BaseTest
         $this->assertStringStartsWith('test_schema', $tableName);
     }
 
-    public function testGetDeleteFromTableSQL() : void
+    public function testGetDeleteFromTableSQL(): void
     {
         $em       = $this->getMockAnnotationReaderEntityManager();
         $metadata = $em->getClassMetadata(self::TEST_ENTITY_GROUP);
@@ -73,7 +73,7 @@ class ORMPurgerTest extends BaseTest
         $this->assertEquals('DELETE FROM "Group"', $sql);
     }
 
-    public function testGetDeleteFromTableSQLWithSchema() : void
+    public function testGetDeleteFromTableSQLWithSchema(): void
     {
         $em       = $this->getMockAnnotationReaderEntityManager();
         $metadata = $em->getClassMetadata(self::TEST_ENTITY_GROUP_WITH_SCHEMA);

--- a/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -17,6 +17,8 @@ use OutOfBoundsException;
 use Prophecy\Prophecy\ProphecyInterface;
 use stdClass;
 
+use function assert;
+
 class ReferenceRepositoryTest extends BaseTest
 {
     public function testReferenceEntry()
@@ -185,16 +187,16 @@ class ReferenceRepositoryTest extends BaseTest
         $role               = new Role();
         $identitiesExpected = ['id' => 1];
 
-        /** @var UnitOfWork | ProphecyInterface $uow */
         $uow = $this->prophesize(UnitOfWork::class);
+        assert($uow instanceof UnitOfWork || $uow instanceof ProphecyInterface);
         $uow->isInIdentityMap($role)->shouldBeCalledTimes(2)->willReturn(true, false);
 
-        /** @var ClassMetadata $classMetadata */
         $classMetadata = $this->prophesize(ClassMetadata::class);
+        assert($classMetadata instanceof ClassMetadata);
         $classMetadata->getIdentifierValues($role)->shouldBeCalled()->willReturn($identitiesExpected);
 
-        /** @var EntityManagerInterface | ProphecyInterface $em */
         $em = $this->prophesize(EntityManagerInterface::class);
+        assert($em instanceof EntityManagerInterface || $em instanceof ProphecyInterface);
         $em->getUnitOfWork()->shouldBeCalled()->willReturn($uow);
         $em->getClassMetadata(Role::class)->shouldBeCalled()->willReturn($classMetadata);
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -21,7 +21,7 @@ use function assert;
 
 class ReferenceRepositoryTest extends BaseTest
 {
-    public function testReferenceEntry()
+    public function testReferenceEntry(): void
     {
         $em = $this->getMockAnnotationReaderEntityManager();
 
@@ -42,7 +42,7 @@ class ReferenceRepositoryTest extends BaseTest
         $this->assertInstanceOf(Role::class, $references['test']);
     }
 
-    public function testReferenceIdentityPopulation()
+    public function testReferenceIdentityPopulation(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = $this->getMockBuilder(ReferenceRepository::class)
@@ -73,7 +73,7 @@ class ReferenceRepositoryTest extends BaseTest
         $roleFixture->load($em);
     }
 
-    public function testReferenceReconstruction()
+    public function testReferenceReconstruction(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ReferenceRepository($em);
@@ -99,7 +99,7 @@ class ReferenceRepositoryTest extends BaseTest
         $this->assertInstanceOf(Proxy::class, $ref);
     }
 
-    public function testReferenceMultipleEntries()
+    public function testReferenceMultipleEntries(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ReferenceRepository($em);
@@ -120,7 +120,7 @@ class ReferenceRepositoryTest extends BaseTest
         $this->assertInstanceOf(Proxy::class, $referenceRepository->getReference('duplicate'));
     }
 
-    public function testUndefinedReference()
+    public function testUndefinedReference(): void
     {
         $referenceRepository = new ReferenceRepository($this->getMockSqliteEntityManager());
 
@@ -130,7 +130,7 @@ class ReferenceRepositoryTest extends BaseTest
         $referenceRepository->getReference('foo');
     }
 
-    public function testThrowsExceptionAddingDuplicatedReference()
+    public function testThrowsExceptionAddingDuplicatedReference(): void
     {
         $referenceRepository = new ReferenceRepository($this->getMockSqliteEntityManager());
         $referenceRepository->addReference('duplicated_reference', new stdClass());
@@ -141,7 +141,7 @@ class ReferenceRepositoryTest extends BaseTest
         $referenceRepository->addReference('duplicated_reference', new stdClass());
     }
 
-    public function testThrowsExceptionTryingToGetWrongReference()
+    public function testThrowsExceptionTryingToGetWrongReference(): void
     {
         $referenceRepository = new ReferenceRepository($this->getMockSqliteEntityManager());
 
@@ -151,7 +151,7 @@ class ReferenceRepositoryTest extends BaseTest
         $referenceRepository->getReference('missing_reference');
     }
 
-    public function testHasIdentityCheck()
+    public function testHasIdentityCheck(): void
     {
         $role                = new Role();
         $referenceRepository = new ReferenceRepository($this->getMockSqliteEntityManager());
@@ -162,7 +162,7 @@ class ReferenceRepositoryTest extends BaseTest
         $this->assertEquals(['entity' => $role], $referenceRepository->getIdentities());
     }
 
-    public function testSetReferenceHavingIdentifier()
+    public function testSetReferenceHavingIdentifier(): void
     {
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ReferenceRepository($em);
@@ -182,7 +182,7 @@ class ReferenceRepositoryTest extends BaseTest
         $this->assertArrayHasKey('entity', $identities);
     }
 
-    public function testGetIdentifierWhenHasNotBeenManagedYetByUnitOfWork()
+    public function testGetIdentifierWhenHasNotBeenManagedYetByUnitOfWork(): void
     {
         $role               = new Role();
         $identitiesExpected = ['id' => 1];
@@ -192,7 +192,6 @@ class ReferenceRepositoryTest extends BaseTest
         $uow->isInIdentityMap($role)->shouldBeCalledTimes(2)->willReturn(true, false);
 
         $classMetadata = $this->prophesize(ClassMetadata::class);
-        assert($classMetadata instanceof ClassMetadata);
         $classMetadata->getIdentifierValues($role)->shouldBeCalled()->willReturn($identitiesExpected);
 
         $em = $this->prophesize(EntityManagerInterface::class);

--- a/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
@@ -21,7 +21,7 @@ use RuntimeException;
  */
 class TopologicalSorterTest extends BaseTest
 {
-    public function testSuccessSortLinearDependency()
+    public function testSuccessSortLinearDependency(): void
     {
         $sorter = new TopologicalSorter();
 
@@ -48,7 +48,7 @@ class TopologicalSorterTest extends BaseTest
         self::assertSame($correctList, $sortedList);
     }
 
-    public function testSuccessSortMultiDependency()
+    public function testSuccessSortMultiDependency(): void
     {
         $sorter = new TopologicalSorter();
 
@@ -76,7 +76,7 @@ class TopologicalSorterTest extends BaseTest
         self::assertSame($correctList, $sortedList);
     }
 
-    public function testSortCyclicDependency()
+    public function testSortCyclicDependency(): void
     {
         $sorter = new TopologicalSorter();
 
@@ -100,7 +100,7 @@ class TopologicalSorterTest extends BaseTest
         $sorter->sort();
     }
 
-    public function testFailureSortCyclicDependency()
+    public function testFailureSortCyclicDependency(): void
     {
         $sorter = new TopologicalSorter(false);
 
@@ -121,7 +121,7 @@ class TopologicalSorterTest extends BaseTest
         $sorter->sort();
     }
 
-    public function testNoFailureOnSelfReferencingDependency()
+    public function testNoFailureOnSelfReferencingDependency(): void
     {
         $sorter = new TopologicalSorter();
 
@@ -149,7 +149,7 @@ class TopologicalSorterTest extends BaseTest
         self::assertSame($correctList, $sortedList);
     }
 
-    public function testFailureSortMissingDependency()
+    public function testFailureSortMissingDependency(): void
     {
         $sorter = new TopologicalSorter();
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/Sorter/VertexTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Sorter/VertexTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\Common\DataFixtures\BaseTest;
  */
 class VertexTest extends BaseTest
 {
-    public function testNode()
+    public function testNode(): void
     {
         $value = new ClassMetadata('\Sample\Entity');
         $node  = new Vertex($value);

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestDocument/Role.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestDocument/Role.php
@@ -26,17 +26,17 @@ class Role
      */
     private $name;
 
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Group.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Group.php
@@ -27,22 +27,22 @@ class Group
      */
     private $code;
 
-    public function setId($id) : void
+    public function setId($id): void
     {
         $this->id = $id;
     }
 
-    public function getId() : ?int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setCode($code) : void
+    public function setCode($code): void
     {
         $this->code = $code;
     }
 
-    public function getCode() : ?string
+    public function getCode(): ?string
     {
         return $this->code;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Group.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Group.php
@@ -27,7 +27,7 @@ class Group
      */
     private $code;
 
-    public function setId($id): void
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -37,7 +37,7 @@ class Group
         return $this->id;
     }
 
-    public function setCode($code): void
+    public function setCode(string $code): void
     {
         $this->code = $code;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
@@ -28,7 +28,7 @@ class GroupWithSchema
      */
     private $code;
 
-    public function setId($id): void
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -38,7 +38,7 @@ class GroupWithSchema
         return $this->id;
     }
 
-    public function setCode($code): void
+    public function setCode(string $code): void
     {
         $this->code = $code;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
@@ -28,22 +28,22 @@ class GroupWithSchema
      */
     private $code;
 
-    public function setId($id) : void
+    public function setId($id): void
     {
         $this->id = $id;
     }
 
-    public function getId() : ?int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setCode($code) : void
+    public function setCode($code): void
     {
         $this->code = $code;
     }
 
-    public function getCode() : ?string
+    public function getCode(): ?string
     {
         return $this->code;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Link.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Link.php
@@ -23,7 +23,7 @@ class Link
     /**
      * @ORM\Column(length=150)
      *
-     * @var string
+     * @var string|null
      */
     private $url;
 
@@ -32,17 +32,17 @@ class Link
         $this->id = $id;
     }
 
-    public function getId()
+    public function getId(): Uuid
     {
         return $this->id;
     }
 
-    public function getUrl()
+    public function getUrl(): ?string
     {
         return $this->url;
     }
 
-    public function setUrl($url)
+    public function setUrl(string $url): void
     {
         $this->url = $url;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Quoted.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Quoted.php
@@ -40,22 +40,22 @@ class Quoted
      */
     private $selects;
 
-    public function getId() : ?int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setId(?int $id) : void
+    public function setId(?int $id): void
     {
         $this->id = $id;
     }
 
-    public function getSelect() : ?string
+    public function getSelect(): ?string
     {
         return $this->select;
     }
 
-    public function setSelect(?string $select) : void
+    public function setSelect(?string $select): void
     {
         $this->select = $select;
     }
@@ -63,7 +63,7 @@ class Quoted
     /**
      * @return Collection|null
      */
-    public function getSelects() : ?Collection
+    public function getSelects(): ?Collection
     {
         return $this->selects;
     }
@@ -71,7 +71,7 @@ class Quoted
     /**
      * @param Collection|null $selects
      */
-    public function setSelects(?Collection $selects) : void
+    public function setSelects(?Collection $selects): void
     {
         $this->selects = $selects;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Role.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/Role.php
@@ -27,17 +27,17 @@ class Role
      */
     private $name;
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/User.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/User.php
@@ -69,7 +69,7 @@ class User
      */
     private $authors;
 
-    public function setId($id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -79,7 +79,7 @@ class User
         return $this->id;
     }
 
-    public function setCode($code)
+    public function setCode(string $code): void
     {
         $this->code = $code;
     }
@@ -89,32 +89,32 @@ class User
         return $this->code;
     }
 
-    public function setPassword($password)
+    public function setPassword(string $password): void
     {
         $this->password = md5($password);
     }
 
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
 
-    public function setEmail($email)
+    public function setEmail(string $email): void
     {
         $this->email = $email;
     }
 
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
-    public function setRole(Role $role)
+    public function setRole(Role $role): void
     {
         $this->role = $role;
     }
 
-    public function getRole()
+    public function getRole(): ?Role
     {
         return $this->role;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/User.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/User.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+
 use function md5;
 
 /**
@@ -73,7 +74,7 @@ class User
         $this->id = $id;
     }
 
-    public function getId() : ?int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -83,7 +84,7 @@ class User
         $this->code = $code;
     }
 
-    public function getCode() : ?string
+    public function getCode(): ?string
     {
         return $this->code;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/UserWithSchema.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/UserWithSchema.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+
 use function md5;
 
 /**
@@ -74,7 +75,7 @@ class UserWithSchema
         $this->id = $id;
     }
 
-    public function getId() : ?int
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -84,7 +85,7 @@ class UserWithSchema
         $this->code = $code;
     }
 
-    public function getCode() : ?string
+    public function getCode(): ?string
     {
         return $this->code;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/UserWithSchema.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/UserWithSchema.php
@@ -59,18 +59,18 @@ class UserWithSchema
      *      inverseJoinColumns={@ORM\JoinColumn(name="reader_id", referencedColumnName="id")}
      * )
      *
-     * @var UserWithSchema[]|Collection
+     * @psalm-var Collection<int, self>
      */
     private $readers;
 
     /**
      * @ORM\ManyToMany(targetEntity=UserWithSchema::class, mappedBy="readers")
      *
-     * @var UserWithSchema[]|Collection
+     * @psalm-var Collection<int, self>
      */
     private $authors;
 
-    public function setId($id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
@@ -80,7 +80,7 @@ class UserWithSchema
         return $this->id;
     }
 
-    public function setCode($code)
+    public function setCode(string $code): void
     {
         $this->code = $code;
     }
@@ -90,50 +90,48 @@ class UserWithSchema
         return $this->code;
     }
 
-    public function setPassword($password)
+    public function setPassword(string $password): void
     {
         $this->password = md5($password);
     }
 
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
 
-    public function setEmail($email)
+    public function setEmail(string $email): void
     {
         $this->email = $email;
     }
 
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->email;
     }
 
-    public function setRole(Role $role)
+    public function setRole(Role $role): void
     {
         $this->role = $role;
     }
 
-    public function getRole()
+    public function getRole(): ?Role
     {
         return $this->role;
     }
 
     /**
-     * @return UserWithSchema[]|Collection
+     * @psalm-return Collection<int, self>
      */
-    public function getReaders()
+    public function getReaders(): Collection
     {
         return $this->readers;
     }
 
     /**
-     * @param UserWithSchema[]|Collection $readers
-     *
-     * @return UserWithSchema
+     * @psalm-param Collection<int, self> $readers
      */
-    public function setReaders($readers)
+    public function setReaders($readers): self
     {
         $this->readers = $readers;
 
@@ -141,7 +139,7 @@ class UserWithSchema
     }
 
     /**
-     * @return UserWithSchema[]|Collection
+     * @psalm-return Collection<int, self>
      */
     public function getAuthors()
     {
@@ -149,11 +147,9 @@ class UserWithSchema
     }
 
     /**
-     * @param UserWithSchema[]|Collection $authors
-     *
-     * @return UserWithSchema
+     * @param Collection<int, self> $authors
      */
-    public function setAuthors($authors)
+    public function setAuthors($authors): self
     {
         $this->authors = $authors;
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/MyFixture1.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/MyFixture1.php
@@ -9,7 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 
 class MyFixture1 implements FixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/MyFixture2.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/MyFixture2.php
@@ -9,7 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 
 class MyFixture2 implements FixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/RoleFixture.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/RoleFixture.php
@@ -14,12 +14,12 @@ class RoleFixture implements SharedFixtureInterface
     /** @var ReferenceRepository|null */
     private $referenceRepository;
 
-    public function setReferenceRepository(ReferenceRepository $referenceRepository)
+    public function setReferenceRepository(ReferenceRepository $referenceRepository): void
     {
         $this->referenceRepository = $referenceRepository;
     }
 
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $adminRole = new Role();
         $adminRole->setName('admin');

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/UserFixture.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestFixtures/UserFixture.php
@@ -10,7 +10,7 @@ use Doctrine\Tests\Common\DataFixtures\TestEntity\User;
 
 class UserFixture extends AbstractFixture
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $admin = new User();
         $admin->setId(4);

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
@@ -19,12 +19,12 @@ class ExcludedEntity
      */
     private $id;
 
-    public function setId($id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
@@ -19,12 +19,12 @@ class IncludedEntity
      */
     private $id;
 
-    public function setId($id)
+    public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestTypes/UuidType.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestTypes/UuidType.php
@@ -14,10 +14,10 @@ class UuidType extends Type
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {
-        $field_declaration['length'] = 36;
-        $field_declaration['fixed']  = true;
+        $fieldDeclaration['length'] = 36;
+        $fieldDeclaration['fixed']  = true;
 
-        return $platform->getVarcharTypeDeclarationSQL($field_declaration);
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
     }
 
     public function convertToPHPValue($value, AbstractPlatform $platform)

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestTypes/UuidType.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestTypes/UuidType.php
@@ -12,7 +12,10 @@ class UuidType extends Type
 {
     public const NAME = 'uuid';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    /**
+     * @param mixed[] $fieldDeclaration
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         $fieldDeclaration['length'] = 36;
         $fieldDeclaration['fixed']  = true;
@@ -20,17 +23,23 @@ class UuidType extends Type
         return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    /**
+     * @param ?string $value
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?Uuid
     {
         return $value === null ? null : new Uuid($value);
     }
 
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    /**
+     * @param ?Uuid $value
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         return $value === null ? null : (string) $value;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::NAME;
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestValueObjects/Uuid.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestValueObjects/Uuid.php
@@ -12,37 +12,40 @@ class Uuid implements JsonSerializable, Serializable
     /** @var string $id */
     private $id;
 
-    public function __construct($id)
+    public function __construct(string $id)
     {
         $this->id = $id;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->id;
     }
 
-    public function serialize()
+    public function serialize(): string
     {
         return $this->id;
     }
 
-    public function unserialize($serialized)
+    /**
+     * @param string $serialized
+     */
+    public function unserialize($serialized): void
     {
         $this->id = $serialized;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->id;
     }
 
-    public static function unknown()
+    public static function unknown(): self
     {
         return new self('00000000-0000-0000-C000-000000000046');
     }


### PR DESCRIPTION
See https://github.com/doctrine/event-manager/pull/33, https://github.com/orgs/doctrine/projects/7#card-50248429.

In order to support PHP 8, the Coding Standard repository needs to be updated.