### PR TITLE
skip test using setFilterSchemaAssetsExpression removed in DBAL3

### DIFF
--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -44,7 +44,9 @@ class ORMPurgerExcludeTest extends BaseTest
 
         $connection    = $em->getConnection();
         $configuration = $connection->getConfiguration();
-        $configuration->setFilterSchemaAssetsExpression(null);
+        if (method_exists($configuration, 'setFilterSchemaAssetsExpression')) {
+            $configuration->setFilterSchemaAssetsExpression(null);
+        }
 
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropDatabase();
@@ -86,7 +88,13 @@ class ORMPurgerExcludeTest extends BaseTest
 
         $connection    = $em->getConnection();
         $configuration = $connection->getConfiguration();
-        $configuration->setFilterSchemaAssetsExpression($expression);
+        if ($expression !== null) {
+            if (! method_exists($configuration, 'setFilterSchemaAssetsExpression')) {
+                $this->markTestSkipped('DBAL 2 is required to test schema assets filters');
+            }
+
+            $configuration->setFilterSchemaAssetsExpression($expression);
+        }
 
         if ($filter !== null) {
             if (! method_exists($configuration, 'setSchemaAssetsFilter')) {


### PR DESCRIPTION
Signed-off-by: Remi Collet <remi@php.net>

CI seems to only use dbal v2, so don't detect this one.

Without this patch:

```
There were 3 errors:

1) Doctrine\Tests\Common\DataFixtures\ORMPurgerExcludeTest::testPurgeExcludeUsingFilterExpression
Error: Call to undefined method Doctrine\ORM\Configuration::setFilterSchemaAssetsExpression()

/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:47
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:77
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:114

2) Doctrine\Tests\Common\DataFixtures\ORMPurgerExcludeTest::testPurgeExcludeUsingList
Error: Call to undefined method Doctrine\ORM\Configuration::setFilterSchemaAssetsExpression()

/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:47
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:77
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:122

3) Doctrine\Tests\Common\DataFixtures\ORMPurgerExcludeTest::testPurgeExcludeUsingFilterCallable
Error: Call to undefined method Doctrine\ORM\Configuration::setFilterSchemaAssetsExpression()

/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:47
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:77
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:129

```

With 

```
$ php81 /usr/bin/phpunit8 --verbose --bootstrap bootstrap.php
PHPUnit 8.5.21 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.0RC3
Configuration: /dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/phpunit.xml.dist

......................SS........................                  48 / 48 (100%)

Time: 151 ms, Memory: 12.00 MB

There were 2 skipped tests:

1) Doctrine\Tests\Common\DataFixtures\Purger\MongoDBPurgerTest::testPurgeKeepsIndices
Missing doctrine/mongodb-odm

/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php:29
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php:52
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php:57

2) Doctrine\Tests\Common\DataFixtures\ORMPurgerExcludeTest::testPurgeExcludeUsingFilterExpression
DBAL 2 is required to test schema assets filters

/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:93
/dev/shm/BUILD/data-fixtures-f18adf13f6c81c67a88360dca359ad474523f8e3/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php:122

OK, but incomplete, skipped, or risky tests!
Tests: 48, Assertions: 117, Skipped: 2.

```