### PR TITLE
Avoid inline literals in titles

### DIFF
--- a/docs/en/how-to/fixture-ordering.rst
+++ b/docs/en/how-to/fixture-ordering.rst
@@ -58,14 +58,14 @@ fixtures, or being careful to leave big gaps, you can declare that your
 fixture must be loaded after some other fixtures, and let the package
 figure out what to do.
 
-namespace MyDataFixtures;
-
-use Doctrine\Common\DataFixtures\AbstractFixture;
-use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Persistence\ObjectManager;
-
 .. code-block:: php
+
     <?php
+    namespace MyDataFixtures;
+
+    use Doctrine\Common\DataFixtures\AbstractFixture;
+    use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+    use Doctrine\Persistence\ObjectManager;
 
     class MyFixture extends AbstractFixture implements DependentFixtureInterface
     {

--- a/docs/en/how-to/fixture-ordering.rst
+++ b/docs/en/how-to/fixture-ordering.rst
@@ -5,10 +5,10 @@ There are two interfaces you can implement in your fixtures to control
 in which order they are going to be loaded.
 
 * By implementing ``OrderedFixtureInterface``, you will be able to
-  specify a priority for each fixture.
+  manually specify a priority for each fixture.
 * By implementing ``DependencyFixtureInterface``, you will be able to
-  which class must be loaded after which classes (note the plural), and
-  let the package figure out the order for you.
+  declare which class must be loaded after which classes (note the
+  plural), and let the package figure out the order for you.
 
 .. note::
     You may implement an interface in a fixture, and another interface
@@ -16,8 +16,8 @@ in which order they are going to be loaded.
     ``FixtureInterface``) in a third one. Implementing both in the same
     fixture is an error.
 
-Controlling the order manually with ``OrderedFixtureInterface``
----------------------------------------------------------------
+Option 1: Controlling the order manually
+----------------------------------------
 
 .. code-block:: php
     <?php
@@ -47,8 +47,8 @@ Controlling the order manually with ``OrderedFixtureInterface``
     loading in a specific order because of references from one fixture
     to the other.
 
-Declaring dependencies with ``DependencyFixtureInterface``
-----------------------------------------------------------
+Option 2: Declaring dependencies
+--------------------------------
 
 If you have many models, and a project that evolves, there may be
 several correct orders. Using ``OrderedFixtureInterface`` may become

--- a/docs/en/how-to/loading-fixtures.rst
+++ b/docs/en/how-to/loading-fixtures.rst
@@ -14,8 +14,8 @@ Creating a fixture class
 Fixture classes have two requirements:
 
 * They must implement ``Doctrine\Common\DataFixtures\FixtureInterface``.
-* If they have a constructor, that constructor should not accept any
-  arguments.
+* If they have a constructor, that constructor should be invokable
+  without arguments.
 
 .. code-block:: php
     <?php

--- a/docs/en/how-to/loading-fixtures.rst
+++ b/docs/en/how-to/loading-fixtures.rst
@@ -12,8 +12,9 @@ Creating a fixture class
 ------------------------
 
 Fixture classes have two requirements:
-- They must implement ``Doctrine\Common\DataFixtures\FixtureInterface``.
-- If they have a constructor, that constructor should not accept any
+
+* They must implement ``Doctrine\Common\DataFixtures\FixtureInterface``.
+* If they have a constructor, that constructor should not accept any
   arguments.
 
 .. code-block:: php
@@ -65,7 +66,7 @@ It is also possible to load a fixture by providing its path:
 
 If you have many fixtures, this can get old pretty fast, and you might
 want to load a whole directory of fixtures instead of making one call
-per fixtures.
+per fixture.
 
 .. code-block:: php
     <?php


### PR DESCRIPTION
They result in weird links weird inline literals are replaced with
hashes.
Let us also add missing words in sentences above, this should make it
easier to figure out that these are the same 2 options as below, or just
make sentences correct.

![Screenshot 2022-03-26 at 12-21-17 Doctrine Data Fixtures - Doctrine Data fixtures](https://user-images.githubusercontent.com/657779/160237621-79b4b69c-5513-431a-b225-215cc068d513.png)

I had to fiddle with CSS properties to make these links appear. Maybe this fix will result in the following weird behavior to disappear as well?

![Peek 2022-03-26 11-51](https://user-images.githubusercontent.com/657779/160237644-a4ae5037-f8d2-44ac-bda2-f652ae317ece.gif)
