### PR TITLE
Indicate support for persistence 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "doctrine/common": "^2.13|^3.0",
-        "doctrine/persistence": "^1.3.3|^2.0"
+        "doctrine/persistence": "^1.3.3|^2.0|^3.0"
     },
     "conflict": {
         "doctrine/phpcr-odm": "<1.3.0",


### PR DESCRIPTION
The data-fixtures library should be compatible with version 3 of doctrine/persistence right away. I've run the test suite locally with ORM 2.12-dev and Persistence 3.0.0 and none of the ORM-related tests were failing.

The ODM is not ready yet which is why we cannot run tests with Persistence 3 in our CI yet.

Merging this PR would unlock getting support for Persistence 3 into other repositories, e.g. Symfony.