### PR TITLE
Migrate to `wrapInTransaction()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,16 @@
         "doctrine/persistence": "^1.3.3|^2.0|^3.0"
     },
     "conflict": {
-        "doctrine/phpcr-odm": "<1.3.0",
-        "doctrine/dbal": "<2.13"
+        "doctrine/dbal": "<2.13",
+        "doctrine/orm": "<2.10",
+        "doctrine/phpcr-odm": "<1.3.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",
         "doctrine/coding-standard": "^9.0",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
-        "doctrine/orm": "^2.7.0",
+        "doctrine/orm": "^2.10.0",
         "jangregor/phpstan-prophecy": "^1",
         "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^8.5 || ^9.5",

--- a/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Executor/ORMExecutorTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\DataFixtures\Executor;
 
+use Closure;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Tests\Common\DataFixtures\BaseTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -54,6 +57,16 @@ class ORMExecutorTest extends BaseTest
             ->method('load')
             ->with($em);
         $executor->execute([$fixture], true);
+    }
+
+    public function testCustomLegacyEntityManager(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getEventManager')->willReturn($this->createMock(EventManager::class));
+        $em->expects($this->once())->method('transactional')->with(self::isInstanceOf(Closure::class));
+
+        $executor = new ORMExecutor($em);
+        @$executor->execute([]);
     }
 
     /**


### PR DESCRIPTION
The `transactional()` method of the ORM's entity manager has been deprecated. This PR makes sure we call the new method instead.