### PR TITLE
Migrate to ORMSetup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "conflict": {
         "doctrine/dbal": "<2.13",
-        "doctrine/orm": "<2.10",
+        "doctrine/orm": "<2.12",
         "doctrine/phpcr-odm": "<1.3.0"
     },
     "require-dev": {
@@ -27,7 +27,7 @@
         "doctrine/coding-standard": "^9.0",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
-        "doctrine/orm": "^2.10.0",
+        "doctrine/orm": "^2.12",
         "jangregor/phpstan-prophecy": "^1",
         "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^8.5 || ^9.5",

--- a/tests/Doctrine/Tests/Common/DataFixtures/BaseTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/BaseTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Common\DataFixtures;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\ORMSetup;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ abstract class BaseTest extends TestCase
     protected function getMockAnnotationReaderEntityManager()
     {
         $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
-        $config   = Setup::createAnnotationMetadataConfiguration([__DIR__ . '/TestEntity'], true, null, null, false);
+        $config   = ORMSetup::createAnnotationMetadataConfiguration([__DIR__ . '/TestEntity'], true);
 
         return EntityManager::create($dbParams, $config);
     }
@@ -37,7 +37,7 @@ abstract class BaseTest extends TestCase
     protected function getMockSqliteEntityManager()
     {
         $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
-        $config   = Setup::createAnnotationMetadataConfiguration([__DIR__ . '/TestEntity'], true, null, null, false);
+        $config   = ORMSetup::createAnnotationMetadataConfiguration([__DIR__ . '/TestEntity'], true);
 
         return EntityManager::create($dbParams, $config);
     }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -6,8 +6,8 @@ namespace Doctrine\Tests\Common\DataFixtures;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\ORM\Tools\Setup;
 use Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\ExcludedEntity;
 use Doctrine\Tests\Common\DataFixtures\TestPurgeEntity\IncludedEntity;
 
@@ -33,13 +33,7 @@ class ORMPurgerExcludeTest extends BaseTest
         }
 
         $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
-        $config   = Setup::createAnnotationMetadataConfiguration(
-            [__DIR__ . '/../TestPurgeEntity'],
-            true,
-            null,
-            null,
-            false
-        );
+        $config   = ORMSetup::createAnnotationMetadataConfiguration([__DIR__ . '/../TestPurgeEntity'], true);
         $em       = EntityManager::create($dbParams, $config);
 
         $connection    = $em->getConnection();


### PR DESCRIPTION
This PR switches the test setup to the new `ORMSetup` class introduced with ORM 2.12.