### PR TITLE
Address deprecation from doctrine/orm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/coding-standard": "^9.0",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
-        "doctrine/orm": "^2.7.0",
+        "doctrine/orm": "^2.10.0",
         "jangregor/phpstan-prophecy": "^1",
         "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^8.5 || ^9.5",

--- a/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/ORMExecutor.php
@@ -65,7 +65,7 @@ class ORMExecutor extends AbstractExecutor
     public function execute(array $fixtures, $append = false)
     {
         $executor = $this;
-        $this->em->transactional(static function (EntityManagerInterface $em) use ($executor, $fixtures, $append) {
+        $this->em->wrapInTransaction(static function (EntityManagerInterface $em) use ($executor, $fixtures, $append) {
             if ($append === false) {
                 $executor->purge();
             }


### PR DESCRIPTION
`transactional()` has been deprecated in favor of `wrapInTransaction()`.