### PR TITLE
Avoid prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
         "doctrine/orm": "^2.7.0",
-        "jangregor/phpstan-prophecy": "^1",
         "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^8.5 || ^9.5",
         "symfony/cache": "^5.0 || ^6.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,4 +7,3 @@ parameters:
 
 includes:
     - phpstan-baseline.neon
-    - vendor/jangregor/phpstan-prophecy/extension.neon


### PR DESCRIPTION
It is no longer bundled by default in PHPUnit, which causes a build
failure. Rather than requiring the missing package, migrating to PHPUnit
mocks should result in code easier to analyse by SA tools.

Fixes #401