### PR TITLE
Avoid purging unrelated tables

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -179,16 +179,18 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
                 $sorter->addNode($class->name, $class);
             }
 
-            // $class before its parents
-            foreach ($class->parentClasses as $parentClass) {
-                $parentClass     = $em->getClassMetadata($parentClass);
-                $parentClassName = $parentClass->getName();
+            if ($class->isInheritanceTypeJoined() || $class->isInheritanceTypeSingleTable()) {
+                // $class before its parents
+                foreach ($class->parentClasses as $parentClass) {
+                    $parentClass = $em->getClassMetadata($parentClass);
+                    $parentClassName = $parentClass->getName();
 
-                if (! $sorter->hasNode($parentClassName)) {
-                    $sorter->addNode($parentClassName, $parentClass);
+                    if (!$sorter->hasNode($parentClassName)) {
+                        $sorter->addNode($parentClassName, $parentClass);
+                    }
+
+                    $sorter->addDependency($class->name, $parentClassName);
                 }
-
-                $sorter->addDependency($class->name, $parentClassName);
             }
 
             foreach ($class->associationMappings as $assoc) {
@@ -208,15 +210,17 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
                 $sorter->addDependency($targetClassName, $class->name);
 
                 // parents of $targetClass before $class, too
-                foreach ($targetClass->parentClasses as $parentClass) {
-                    $parentClass     = $em->getClassMetadata($parentClass);
-                    $parentClassName = $parentClass->getName();
+                if ($targetClass->isInheritanceTypeJoined() || $targetClass->isInheritanceTypeSingleTable()) {
+                    foreach ($targetClass->parentClasses as $parentClass) {
+                        $parentClass = $em->getClassMetadata($parentClass);
+                        $parentClassName = $parentClass->getName();
 
-                    if (! $sorter->hasNode($parentClassName)) {
-                        $sorter->addNode($parentClassName, $parentClass);
+                        if (!$sorter->hasNode($parentClassName)) {
+                            $sorter->addNode($parentClassName, $parentClass);
+                        }
+
+                        $sorter->addDependency($parentClassName, $class->name);
                     }
-
-                    $sorter->addDependency($parentClassName, $class->name);
                 }
             }
         }


### PR DESCRIPTION
Assume the following class hierarchy:

```php
/** @Entity */
class Parent {
    // @Id and other attributes here
}

/** @Entity */
class Child extends Parent {
    // @Id and other attributes here
}
```

Both entities have their own, completely unrelated database tables.

I think it is ok (at least, I have a project where it seems to work) to have two different Entity Managers configured, and the first one knows only about the `Parent`, the other about the `Child` entity.

When using the `ORMPurger` with the EntityManager for class `Child`, it should not try to truncate/delete the `parent` table. This is what this PR tries to do – do not include another table when we're not dependent on it, when there is no inheritance mapping relationship.

(OTOH, I'm a bit unsure if the approach is sane... Can the `Child` Entity Manager _not_ know about `Parent`? If it needs to know that class, the way the ORMPurger works would be to include that table as well, since the ORMPurge purges all tables managed by a given EntityManager?)