### PR TITLE
Don't purge read-only marked table

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -121,6 +121,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
             if (
                 (isset($class->isEmbeddedClass) && $class->isEmbeddedClass) ||
                 $class->isMappedSuperclass ||
+                $class->isReadOnly ||
                 ($class->isInheritanceTypeSingleTable() && $class->name !== $class->rootEntityName)
             ) {
                 continue;


### PR DESCRIPTION
It makes no sense to purge tables marked as read-only