### PR TITLE
Revert "Don't purge read-only marked table"

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -121,7 +121,6 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
             if (
                 (isset($class->isEmbeddedClass) && $class->isEmbeddedClass) ||
                 $class->isMappedSuperclass ||
-                $class->isReadOnly ||
                 ($class->isInheritanceTypeSingleTable() && $class->name !== $class->rootEntityName)
             ) {
                 continue;


### PR DESCRIPTION
This reverts commit c152bb18b0a5aecb804672ce99253837891dac11. As pointed out in https://github.com/doctrine/data-fixtures/pull/405#issuecomment-1252383158 the read-only name is misleading, it only means rows cannot be updated, but they can still be inserted.