### PR TITLE
Disable foreign key checks on purge for all mysql versions

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -288,6 +288,9 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
         $sql = $platform->getTruncateTableSQL($tbl, true);
 
         if ($connection->getDriver() instanceof AbstractMySQLDriver) {
+            // MySQL TRUNCATE TABLE Statement: fails for an InnoDB or NDB table
+            // if there are any FOREIGN KEY constraints from other tables that
+            // reference the table.
             $sql = 'SET FOREIGN_KEY_CHECKS = 0;' . $sql . ';SET FOREIGN_KEY_CHECKS = 1;';
         }
 

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\MockObject\MockObject;
 
 use function array_reverse;
 use function array_search;
@@ -289,7 +290,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
         return 'DELETE FROM ' . $tableIdentifier->getQuotedName($platform);
     }
 
-    private function disableForeignKeyChecksForMySQL(Connection $connection)
+    private function disableForeignKeyChecksForMySQL(Connection $connection): void
     {
         if ($this->purgeMode !== self::PURGE_MODE_TRUNCATE || ! $this->isMySQL($connection)) {
             return;
@@ -302,7 +303,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
         $connection->executeStatement('SET FOREIGN_KEY_CHECKS = 0');
     }
 
-    private function enableForeignKeyChecksForMySQL(Connection $connection)
+    private function enableForeignKeyChecksForMySQL(Connection $connection): void
     {
         if ($this->purgeMode !== self::PURGE_MODE_TRUNCATE || ! $this->isMySQL($connection)) {
             return;

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -288,7 +288,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
         $sql = $platform->getTruncateTableSQL($tbl, true);
 
         if ($connection->getDriver() instanceof AbstractMySQLDriver) {
-            $sql = 'SET FOREIGN_KEY_CHECKS = 0;'.$sql.';SET FOREIGN_KEY_CHECKS = 1;';
+            $sql = 'SET FOREIGN_KEY_CHECKS = 0;' . $sql . ';SET FOREIGN_KEY_CHECKS = 1;';
         }
 
         return $sql;

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -283,14 +283,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
         return 'DELETE FROM ' . $tableIdentifier->getQuotedName($platform);
     }
 
-    /**
-     * @param AbstractPlatform $platform
-     * @param Connection       $connection
-     * @param string           $tbl
-     *
-     * @return string
-     */
-    private function getTruncateTableSQL(AbstractPlatform $platform, Connection $connection, $tbl)
+    private function getTruncateTableSQL(AbstractPlatform $platform, Connection $connection, string $tbl): string
     {
         $sql = $platform->getTruncateTableSQL($tbl, true);
 

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use PHPUnit\Framework\MockObject\MockObject;
 
 use function array_reverse;
 use function array_search;

--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -166,7 +166,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
             if ($this->purgeMode === self::PURGE_MODE_DELETE) {
                 $connection->executeStatement($this->getDeleteFromTableSQL($tbl, $platform));
             } else {
-                $connection->executeStatement($platform->getTruncateTableSQL($tbl));
+                $connection->executeStatement($platform->getTruncateTableSQL($tbl, true));
             }
         }
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Tests\Common\DataFixtures\TestEntity\Link;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ORMPurgerForeignKeyCheckTest extends BaseTest
 {

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Common\DataFixtures;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
@@ -9,18 +11,13 @@ use Doctrine\DBAL\Driver\AbstractMySQLDriver;
 use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
 use ReflectionClass;
 
-/**
- * @author Robert Freigang <robertfreigang@gmx.de>
- */
 class ORMPurgerForeignKeyCheckTest extends BaseTest
 {
-    const FOREIGN_KEY_CHECK_STRING_START = 'SET FOREIGN_KEY_CHECKS = 0;';
-    const FOREIGN_KEY_CHECK_STRING_END = ';SET FOREIGN_KEY_CHECKS = 1;';
-    const TEST_TABLE_NAME = 'test_table_name';
+    public const FOREIGN_KEY_CHECK_STRING_START = 'SET FOREIGN_KEY_CHECKS = 0;';
+    public const FOREIGN_KEY_CHECK_STRING_END   = ';SET FOREIGN_KEY_CHECKS = 1;';
+    public const TEST_TABLE_NAME                = 'test_table_name';
 
-    /**
-     * @dataProvider purgeForDifferentDriversProvider
-     */
+    /** @dataProvider purgeForDifferentDriversProvider */
     public function testPurgeForDifferentDrivers(Driver $driver, bool $hasForeignKeyCheckString): void
     {
         $truncateTableSQL = $this->getTruncateTableSQLForDriver($driver);
@@ -36,9 +33,7 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
         $this->assertStringContainsString(self::TEST_TABLE_NAME, $truncateTableSQL);
     }
 
-    /**
-     * @return list<array{Driver, bool}>
-     */
+    /** @return list<array{Driver, bool}> */
     public function purgeForDifferentDriversProvider()
     {
         return [
@@ -56,16 +51,14 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
         $connection = $this->createMock(Connection::class);
         $connection->method('getDriver')->willReturn($driver);
 
-        $purger = new ORMPurger($em);
-        $purgerClass = new ReflectionClass(ORMPurger::class);
+        $purger                    = new ORMPurger($em);
+        $purgerClass               = new ReflectionClass(ORMPurger::class);
         $getTruncateTableSQLMethod = $purgerClass->getMethod('getTruncateTableSQL');
         $getTruncateTableSQLMethod->setAccessible(true);
 
-        $truncateTableSQL = $getTruncateTableSQLMethod->invokeArgs(
+        return $getTruncateTableSQLMethod->invokeArgs(
             $purger,
             [$platform, $connection, self::TEST_TABLE_NAME]
         );
-
-        return $truncateTableSQL;
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Doctrine\Tests\Common\DataFixtures;
+
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\AbstractMySQLDriver;
+use Doctrine\DBAL\Driver\AbstractSQLiteDriver;
+use ReflectionClass;
+
+/**
+ * @author Robert Freigang <robertfreigang@gmx.de>
+ *
+ * @covers ORMPurger::getTruncateTableSQL
+ */
+class ORMPurgerForeignKeyCheckTest extends BaseTest
+{
+    const FOREIGN_KEY_CHECK_STRING_START = 'SET FOREIGN_KEY_CHECKS = 0;';
+    const FOREIGN_KEY_CHECK_STRING_END = ';SET FOREIGN_KEY_CHECKS = 1;';
+    const TEST_TABLE_NAME = 'test_table_name';
+
+    /**
+     * @param Driver $driver
+     * @param bool   $hasForeignKeyCheckString
+     *
+     * @dataProvider purgeForDifferentDriversProvider
+     */
+    public function testPurgeForDifferentDrivers(Driver $driver, $hasForeignKeyCheckString)
+    {
+        $truncateTableSQL = $this->getTruncateTableSQLForDriver($driver);
+
+        if ($hasForeignKeyCheckString) {
+            $this->assertStringStartsWith(self::FOREIGN_KEY_CHECK_STRING_START, $truncateTableSQL);
+            $this->assertStringEndsWith(self::FOREIGN_KEY_CHECK_STRING_END, $truncateTableSQL);
+        } else {
+            $this->assertNotContains(self::FOREIGN_KEY_CHECK_STRING_START, $truncateTableSQL);
+            $this->assertNotContains(self::FOREIGN_KEY_CHECK_STRING_END, $truncateTableSQL);
+        }
+
+        $this->assertContains(self::TEST_TABLE_NAME, $truncateTableSQL);
+    }
+
+    /**
+     * @return array
+     */
+    public function purgeForDifferentDriversProvider()
+    {
+        return [
+            [$this->createMock(AbstractMySQLDriver::class), true],
+            [$this->createMock(AbstractSQLiteDriver::class), false],
+        ];
+    }
+
+    /**
+     * @param Driver $driver
+     *
+     * @return string
+     */
+    private function getTruncateTableSQLForDriver(Driver $driver)
+    {
+        $em = $this->getMockAnnotationReaderEntityManager();
+
+        $platform = $em->getConnection()->getDatabasePlatform();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDriver')->willReturn($driver);
+
+        $purger = new ORMPurger($em);
+        $purgerClass = new ReflectionClass(ORMPurger::class);
+        $getTruncateTableSQLMethod = $purgerClass->getMethod('getTruncateTableSQL');
+        $getTruncateTableSQLMethod->setAccessible(true);
+
+        $truncateTableSQL = $getTruncateTableSQLMethod->invokeArgs(
+            $purger,
+            [$platform, $connection, self::TEST_TABLE_NAME]
+        );
+
+        return $truncateTableSQL;
+    }
+}

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
@@ -11,8 +11,6 @@ use ReflectionClass;
 
 /**
  * @author Robert Freigang <robertfreigang@gmx.de>
- *
- * @covers ORMPurger::getTruncateTableSQL
  */
 class ORMPurgerForeignKeyCheckTest extends BaseTest
 {
@@ -21,12 +19,9 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
     const TEST_TABLE_NAME = 'test_table_name';
 
     /**
-     * @param Driver $driver
-     * @param bool   $hasForeignKeyCheckString
-     *
      * @dataProvider purgeForDifferentDriversProvider
      */
-    public function testPurgeForDifferentDrivers(Driver $driver, $hasForeignKeyCheckString)
+    public function testPurgeForDifferentDrivers(Driver $driver, bool $hasForeignKeyCheckString): void
     {
         $truncateTableSQL = $this->getTruncateTableSQLForDriver($driver);
 
@@ -34,15 +29,15 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
             $this->assertStringStartsWith(self::FOREIGN_KEY_CHECK_STRING_START, $truncateTableSQL);
             $this->assertStringEndsWith(self::FOREIGN_KEY_CHECK_STRING_END, $truncateTableSQL);
         } else {
-            $this->assertNotContains(self::FOREIGN_KEY_CHECK_STRING_START, $truncateTableSQL);
-            $this->assertNotContains(self::FOREIGN_KEY_CHECK_STRING_END, $truncateTableSQL);
+            $this->assertStringNotContainsString(self::FOREIGN_KEY_CHECK_STRING_START, $truncateTableSQL);
+            $this->assertStringNotContainsString(self::FOREIGN_KEY_CHECK_STRING_END, $truncateTableSQL);
         }
 
-        $this->assertContains(self::TEST_TABLE_NAME, $truncateTableSQL);
+        $this->assertStringContainsString(self::TEST_TABLE_NAME, $truncateTableSQL);
     }
 
     /**
-     * @return array
+     * @return list<array{Driver, bool}>
      */
     public function purgeForDifferentDriversProvider()
     {
@@ -52,12 +47,7 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
         ];
     }
 
-    /**
-     * @param Driver $driver
-     *
-     * @return string
-     */
-    private function getTruncateTableSQLForDriver(Driver $driver)
+    private function getTruncateTableSQLForDriver(Driver $driver): string
     {
         $em = $this->getMockAnnotationReaderEntityManager();
 

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
@@ -30,7 +30,7 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
         $metadataDriver = $this->createMock(MappingDriver::class);
         $metadataDriver->method('getAllClassNames')->willReturn([self::TEST_CLASS_NAME]);
         $metadataDriver->method('loadMetadataForClass')
-            ->willReturnCallback(static function (string $className, ClassMetadata $metadata) {
+            ->willReturnCallback(static function (string $className, ClassMetadata $metadata): void {
                 if ($className !== self::TEST_CLASS_NAME) {
                     return;
                 }
@@ -92,7 +92,7 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
     }
 
     /** @return list<array{AbstractPlatform, ORMPurger::PURGE_MODE_*, bool}> */
-    public function purgeForDifferentPlatformsProvider()
+    public function purgeForDifferentPlatformsProvider(): array
     {
         return [
             [new MySQLPlatform(), ORMPurger::PURGE_MODE_TRUNCATE, true],

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerForeignKeyCheckTest.php
@@ -23,8 +23,8 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
     public const TEST_CLASS_NAME = Link::class;
     public const TEST_TABLE_NAME = 'link';
 
-    /** @return MappingDriver */
-    protected function getMockMetadataDriver()
+    /** @return MappingDriver&MockObject */
+    protected function getMockMetadataDriver(): MappingDriver
     {
         $metadataDriver = $this->createMock(MappingDriver::class);
         $metadataDriver->method('getAllClassNames')->willReturn([self::TEST_CLASS_NAME]);
@@ -42,8 +42,8 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
         return $metadataDriver;
     }
 
-    /** @return Connection */
-    protected function getMockConnectionForPlatform(AbstractPlatform $platform)
+    /** @return Connection&MockObject */
+    protected function getMockConnectionForPlatform(AbstractPlatform $platform): Connection
     {
         $driver = $this->createMock(AbstractDriverMiddleware::class);
         $driver->method('getDatabasePlatform')->willReturn($platform);
@@ -90,7 +90,7 @@ class ORMPurgerForeignKeyCheckTest extends BaseTest
         $purger->purge();
     }
 
-    /** @return list<array{AbstractPlatform, int, bool}> */
+    /** @return list<array{AbstractPlatform, ORMPurger::PURGE_MODE_*, bool}> */
     public function purgeForDifferentPlatformsProvider()
     {
         return [


### PR DESCRIPTION
For your consideration, see #272. I don't know if the discussion was a yes/no to this feature.

I can push a little refactor of `getTruncateTableSQL()` to make it fit better.