### PR TITLE
Implement reference by class names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ext-sqlite3": "*",
         "doctrine/coding-standard": "^10.0",
         "doctrine/dbal": "^2.13 || ^3.0",
+        "doctrine/deprecations": "^1.0",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
         "doctrine/orm": "^2.12",
         "phpstan/phpstan": "^1.5",

--- a/docs/en/how-to/sharing-objects-between-fixtures.rst
+++ b/docs/en/how-to/sharing-objects-between-fixtures.rst
@@ -58,7 +58,7 @@ And the ``User`` data loading fixture:
             $user->setUsername('jwage');
             $user->setPassword('test');
             $user->setRole(
-                $this->getReference('admin-role') // load the stored reference
+                $this->getReference('admin-role', Role::class) // load the stored reference
             );
 
             $manager->persist($user);

--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -71,13 +71,25 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::getReference
      *
-     * @param string $name
+     * @param string      $name
+     * @param string|null $class
      *
      * @return object
+     *
+     * @template T of object
+     * @psalm-param class-string<T>|null $class
+     * @psalm-return $class is null ? object : T
      */
-    public function getReference($name)
+    public function getReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
     {
-        return $this->referenceRepository->getReference($name);
+        if ($class === null) {
+            @trigger_error(sprintf(
+                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        return $this->referenceRepository->getReference($name, $class);
     }
 
     /**
@@ -86,12 +98,22 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::hasReference
      *
-     * @param string $name
+     * @param string      $name
+     * @param string|null $class
      *
      * @return bool
+     *
+     * @psalm-param class-string $class
      */
-    public function hasReference($name)
+    public function hasReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
     {
-        return $this->referenceRepository->hasReference($name);
+        if ($class === null) {
+            @trigger_error(sprintf(
+                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        return $this->referenceRepository->hasReference($name, $class);
     }
 }

--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -72,8 +72,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::getReference
      *
-     * @param string      $name
-     * @param string|null $class
+     * @param string $name
      * @psalm-param class-string<T>|null $class
      *
      * @return object
@@ -81,7 +80,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @template T of object
      */
-    public function getReference($name, $class = null)
+    public function getReference($name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -101,13 +100,12 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::hasReference
      *
-     * @param string      $name
-     * @param string|null $class
+     * @param string $name
      * @psalm-param class-string $class
      *
      * @return bool
      */
-    public function hasReference($name, $class = null)
+    public function hasReference($name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(

--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -87,7 +87,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
             Deprecation::trigger(
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
-                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                'Argument $class of %s() will be mandatory in 2.0.',
                 __METHOD__
             );
         }
@@ -114,7 +114,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
             Deprecation::trigger(
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
-                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                'Argument $class of %s() will be mandatory in 2.0.',
                 __METHOD__
             );
         }

--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Common\DataFixtures;
 
 use BadMethodCallException;
+use Doctrine\Deprecations\Deprecation;
 
 /**
  * Abstract Fixture class helps to manage references
@@ -80,13 +81,15 @@ abstract class AbstractFixture implements SharedFixtureInterface
      * @psalm-param class-string<T>|null $class
      * @psalm-return $class is null ? object : T
      */
-    public function getReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
+    public function getReference($name, $class = null)
     {
         if ($class === null) {
-            @trigger_error(sprintf(
-                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+            Deprecation::trigger(
+                'doctrine/data-fixtures',
+                'https://github.com/doctrine/data-fixtures/pull/409',
+                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
         }
 
         return $this->referenceRepository->getReference($name, $class);
@@ -105,13 +108,15 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @psalm-param class-string $class
      */
-    public function hasReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
+    public function hasReference($name, $class = null)
     {
         if ($class === null) {
-            @trigger_error(sprintf(
-                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+            Deprecation::trigger(
+                'doctrine/data-fixtures',
+                'https://github.com/doctrine/data-fixtures/pull/409',
+                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
         }
 
         return $this->referenceRepository->hasReference($name, $class);

--- a/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
+++ b/lib/Doctrine/Common/DataFixtures/AbstractFixture.php
@@ -74,12 +74,12 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @param string      $name
      * @param string|null $class
+     * @psalm-param class-string<T>|null $class
      *
      * @return object
+     * @psalm-return $class is null ? object : T
      *
      * @template T of object
-     * @psalm-param class-string<T>|null $class
-     * @psalm-return $class is null ? object : T
      */
     public function getReference($name, $class = null)
     {
@@ -103,10 +103,9 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @param string      $name
      * @param string|null $class
+     * @psalm-param class-string $class
      *
      * @return bool
-     *
-     * @psalm-param class-string $class
      */
     public function hasReference($name, $class = null)
     {

--- a/lib/Doctrine/Common/DataFixtures/Event/Listener/MongoDBReferenceListener.php
+++ b/lib/Doctrine/Common/DataFixtures/Event/Listener/MongoDBReferenceListener.php
@@ -49,7 +49,7 @@ final class MongoDBReferenceListener implements EventSubscriber
                 ->getUnitOfWork()
                 ->getDocumentIdentifier($object);
 
-            $this->referenceRepository->setReferenceIdentity($name, $identity);
+            $this->referenceRepository->setReferenceIdentity($name, $identity, get_class($object));
         }
     }
 }

--- a/lib/Doctrine/Common/DataFixtures/Event/Listener/MongoDBReferenceListener.php
+++ b/lib/Doctrine/Common/DataFixtures/Event/Listener/MongoDBReferenceListener.php
@@ -8,6 +8,8 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 
+use function get_class;
+
 /**
  * Reference Listener populates identities for
  * stored references

--- a/lib/Doctrine/Common/DataFixtures/Event/Listener/ORMReferenceListener.php
+++ b/lib/Doctrine/Common/DataFixtures/Event/Listener/ORMReferenceListener.php
@@ -50,7 +50,7 @@ final class ORMReferenceListener implements EventSubscriber
                 ->getUnitOfWork()
                 ->getEntityIdentifier($object);
 
-            $this->referenceRepository->setReferenceIdentity($name, $identity);
+            $this->referenceRepository->setReferenceIdentity($name, $identity, get_class($object));
         }
     }
 }

--- a/lib/Doctrine/Common/DataFixtures/Event/Listener/ORMReferenceListener.php
+++ b/lib/Doctrine/Common/DataFixtures/Event/Listener/ORMReferenceListener.php
@@ -8,6 +8,8 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 
+use function get_class;
+
 /**
  * Reference Listener populates identities for
  * stored references

--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -21,22 +21,6 @@ use function unserialize;
 class ProxyReferenceRepository extends ReferenceRepository
 {
     /**
-     * Get real class name of a reference that could be a proxy
-     *
-     * @param string $className Class name of reference object
-     *
-     * @return string
-     */
-    protected function getRealClass($className)
-    {
-        if (substr($className, -5) === 'Proxy') {
-            return substr($className, 0, -5);
-        }
-
-        return $className;
-    }
-
-    /**
      * Serialize reference repository
      *
      * @return string
@@ -53,8 +37,9 @@ class ProxyReferenceRepository extends ReferenceRepository
         }
 
         return serialize([
-            'references' => $simpleReferences,
-            'identities' => $this->getIdentities(),
+            'references' => $simpleReferences, // For BC, remove in next major.
+            'identities' => $this->getIdentities(), // For BC, remove in next major.
+            'identitiesByClass' => $this->getIdentitiesByClass(),
         ]);
     }
 
@@ -68,22 +53,42 @@ class ProxyReferenceRepository extends ReferenceRepository
     public function unserialize($serializedData)
     {
         $repositoryData = unserialize($serializedData);
-        $references     = $repositoryData['references'];
 
-        foreach ($references as $name => $proxyReference) {
-            $this->setReference(
-                $name,
-                $this->getManager()->getReference(
-                    $proxyReference[0], // entity class name
-                    $proxyReference[1]  // identifiers
-                )
-            );
+        // For BC, remove in next major.
+        if (!isset($repositoryData['identitiesByClass'])) {
+            $references     = $repositoryData['references'];
+
+            foreach ($references as $name => $proxyReference) {
+                $this->setReference(
+                    $name,
+                    $this->getManager()->getReference(
+                        $proxyReference[0], // entity class name
+                        $proxyReference[1]  // identifiers
+                    )
+                );
+            }
+
+            $identities = $repositoryData['identities'];
+
+            foreach ($identities as $name => $identity) {
+                $this->setReferenceIdentity($name, $identity);
+            }
+
+            return;
         }
 
-        $identities = $repositoryData['identities'];
+        foreach ($repositoryData['identitiesByClass'] as $className => $identities) {
+            foreach ($identities as $name => $identity) {
+                $this->setReference(
+                    $name,
+                    $this->getManager()->getReference(
+                        $className,
+                        $identity
+                    )
+                );
 
-        foreach ($identities as $name => $identity) {
-            $this->setReferenceIdentity($name, $identity);
+                $this->setReferenceIdentity($name, $identity, $className);
+            }
         }
     }
 

--- a/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
@@ -9,7 +9,6 @@ use function file_get_contents;
 use function file_put_contents;
 use function get_class;
 use function serialize;
-use function substr;
 use function unserialize;
 
 /**
@@ -55,8 +54,8 @@ class ProxyReferenceRepository extends ReferenceRepository
         $repositoryData = unserialize($serializedData);
 
         // For BC, remove in next major.
-        if (!isset($repositoryData['identitiesByClass'])) {
-            $references     = $repositoryData['references'];
+        if (! isset($repositoryData['identitiesByClass'])) {
+            $references = $repositoryData['references'];
 
             foreach ($references as $name => $proxyReference) {
                 $this->setReference(

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -148,7 +148,7 @@ class ReferenceRepository
             Deprecation::trigger(
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
-                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                'Argument $class of %s() will be mandatory in 2.0.',
                 __METHOD__
             );
         }
@@ -218,7 +218,7 @@ class ReferenceRepository
             Deprecation::trigger(
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
-                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                'Argument $class of %s() will be mandatory in 2.0.',
                 __METHOD__
             );
         }
@@ -271,7 +271,7 @@ class ReferenceRepository
             Deprecation::trigger(
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
-                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                'Argument $class of %s() will be mandatory in 2.0.',
                 __METHOD__
             );
         }
@@ -313,7 +313,7 @@ class ReferenceRepository
             Deprecation::trigger(
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
-                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                'Argument $class of %s() will be mandatory in 2.0.',
                 __METHOD__
             );
         }

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -31,6 +31,14 @@ class ReferenceRepository
     private $references = [];
 
     /**
+     * List of named references to the fixture objects
+     * gathered during loads of fixtures
+     *
+     * @psalm-var array<class-string, array<string, object>>
+     */
+    private $referencesByClass = [];
+
+    /**
      * List of identifiers stored for references
      * in case if reference gets unmanaged, it will
      * use a proxy referenced by this identity
@@ -38,6 +46,15 @@ class ReferenceRepository
      * @psalm-var array<string, mixed>
      */
     private $identities = [];
+
+    /**
+     * List of identifiers stored for references
+     * in case if reference gets unmanaged, it will
+     * use a proxy referenced by this identity
+     *
+     * @psalm-var array<class-string, array<string, mixed>>
+     */
+    private $identitiesByClass = [];
 
     /**
      * Currently used object manager
@@ -63,7 +80,7 @@ class ReferenceRepository
     {
         // In case Reference is not yet managed in UnitOfWork
         if (! $this->hasIdentifier($reference)) {
-            $class = $this->manager->getClassMetadata(get_class($reference));
+            $class = $this->manager->getClassMetadata($this->getRealClass(get_class($reference)));
 
             return $class->getIdentifierValues($reference);
         }
@@ -94,6 +111,11 @@ class ReferenceRepository
      */
     public function setReference($name, $reference)
     {
+        $class = $this->getRealClass(get_class($reference));
+
+        $this->referencesByClass[$class][$name] = $reference;
+
+        // For BC, to be removed in next major.
         $this->references[$name] = $reference;
 
         if (! $this->hasIdentifier($reference)) {
@@ -101,20 +123,36 @@ class ReferenceRepository
         }
 
         // in case if reference is set after flush, store its identity
-        $uow                     = $this->manager->getUnitOfWork();
-        $this->identities[$name] = $this->getIdentifier($reference, $uow);
+        $uow        = $this->manager->getUnitOfWork();
+        $identifier = $this->getIdentifier($reference, $uow);
+
+        $this->identitiesByClass[$class][$name] = $identifier;
+
+        // For BC, to be removed in next major.
+        $this->identities[$name] = $identifier;
     }
 
     /**
      * Store the identifier of a reference
      *
-     * @param string $name
-     * @param mixed  $identity
+     * @param string            $name
+     * @param mixed             $identity
+     * @param class-string|null $class
      *
      * @return void
      */
-    public function setReferenceIdentity($name, $identity)
+    public function setReferenceIdentity($name, $identity, $class = null) // NEXT_MAJOR: Make $class mandatory
     {
+        if ($class === null) {
+            @trigger_error(sprintf(
+                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->identitiesByClass[$class][$name] = $identity;
+
+        // For BC, to be removed in next major.
         $this->identities[$name] = $identity;
     }
 
@@ -136,10 +174,20 @@ class ReferenceRepository
      */
     public function addReference($name, $object)
     {
+        // For BC, to be removed in next major.
         if (isset($this->references[$name])) {
             throw new BadMethodCallException(sprintf(
                 'Reference to "%s" already exists, use method setReference in order to override it',
                 $name
+            ));
+        }
+
+        $class = $this->getRealClass(get_class($object));
+        if (isset($this->referencesByClass[$class][$name])) {
+            throw new BadMethodCallException(sprintf(
+                'Reference to "%s" for class "%s" already exists, use method setReference in order to override it',
+                $name,
+                $class
             ));
         }
 
@@ -151,25 +199,50 @@ class ReferenceRepository
      * named by $name
      *
      * @param string $name
+     * @param string|null $class
      *
      * @return object
      *
+     * @template T of object
+     * @psalm-param class-string<T>|null $class
+     * @psalm-return $class is null ? object : T
+     *
      * @throws OutOfBoundsException - if repository does not exist.
      */
-    public function getReference($name)
+    public function getReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
     {
-        if (! $this->hasReference($name)) {
-            throw new OutOfBoundsException(sprintf('Reference to "%s" does not exist', $name));
+        if ($class === null) {
+            @trigger_error(sprintf(
+                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        $reference = $this->references[$name];
-        $meta      = $this->manager->getClassMetadata(get_class($reference));
+        if (! $this->hasReference($name, $class)) {
+            // For BC, to be removed in next major.
+            if ($class === null) {
+                throw new OutOfBoundsException(sprintf('Reference to "%s" does not exist', $name));
+            }
 
-        if (! $this->manager->contains($reference) && isset($this->identities[$name])) {
-            $reference               = $this->manager->getReference(
-                $meta->name,
-                $this->identities[$name]
-            );
+            throw new OutOfBoundsException(sprintf('Reference to "%s" for class "%s" does not exist', $name, $class));
+        }
+
+        $reference = $class === null
+            ? $this->references[$name] // For BC, to be removed in next major.
+            : $this->referencesByClass[$class][$name];
+
+        $identity = $class === null
+            ? ($this->identities[$name] ?? null) // For BC, to be removed in next major.
+            : ($this->identitiesByClass[$class][$name] ?? null);
+
+        if ($class === null) { // For BC, to be removed in next major.
+            $class = $this->getRealClass(get_class($reference));
+        }
+
+        $meta = $this->manager->getClassMetadata($class);
+
+        if (! $this->manager->contains($reference) && $identity !== null) {
+            $reference               = $this->manager->getReference($meta->name, $identity);
             $this->references[$name] = $reference; // already in identity map
         }
 
@@ -181,12 +254,24 @@ class ReferenceRepository
      * named by $name
      *
      * @param string $name
+     * @param string|null $class
      *
      * @return bool
+     *
+     * @psalm-param class-string $class
      */
-    public function hasReference($name)
+    public function hasReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
     {
-        return isset($this->references[$name]);
+        if ($class === null) {
+            @trigger_error(sprintf(
+                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        return $class === null
+            ? isset($this->references[$name]) // For BC, to be removed in next major.
+            : isset($this->referencesByClass[$class][$name]);
     }
 
     /**
@@ -195,26 +280,43 @@ class ReferenceRepository
      *
      * @param object $reference
      *
-     * @return array
+     * @return array<string>
      */
     public function getReferenceNames($reference)
     {
-        return array_keys($this->references, $reference, true);
+        $class = $this->getRealClass(get_class($reference));
+        if (!isset($this->referencesByClass[$class])) {
+            return [];
+        }
+
+        return array_keys($this->referencesByClass[$class], $reference, true);
     }
 
     /**
      * Checks if reference has identity stored
      *
-     * @param string $name
+     * @param string            $name
+     * @param class-string|null $class
      *
      * @return bool
      */
-    public function hasIdentity($name)
+    public function hasIdentity($name, $class = null) // NEXT_MAJOR: Make $class mandatory
     {
-        return array_key_exists($name, $this->identities);
+        if ($class === null) {
+            @trigger_error(sprintf(
+                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        return $class === null
+            ? array_key_exists($name, $this->identities) // For BC, to be removed in next major.
+            : array_key_exists($class, $this->identitiesByClass) && array_key_exists($name, $this->identitiesByClass[$class]);
     }
 
     /**
+     * @deprecated in favor of getIdentitiesByClass
+     *
      * Get all stored identities
      *
      * @psalm-return array<string, object>
@@ -225,6 +327,18 @@ class ReferenceRepository
     }
 
     /**
+     * Get all stored identities
+     *
+     * @psalm-return array<class-string, array<string, object>>
+     */
+    public function getIdentitiesByClass()
+    {
+        return $this->identitiesByClass;
+    }
+
+    /**
+     * @deprecated in favor of getReferencesByClass
+     *
      * Get all stored references
      *
      * @psalm-return array<string, object>
@@ -232,6 +346,16 @@ class ReferenceRepository
     public function getReferences()
     {
         return $this->references;
+    }
+
+    /**
+     * Get all stored references
+     *
+     * @psalm-return array<class-string, array<string, object>>
+     */
+    public function getReferencesByClass()
+    {
+        return $this->referencesByClass;
     }
 
     /**
@@ -245,9 +369,25 @@ class ReferenceRepository
     }
 
     /**
+     * Get real class name of a reference that could be a proxy
+     *
+     * @param string $className Class name of reference object
+     *
+     * @return string
+     */
+    protected function getRealClass($className)
+    {
+        if (substr($className, -5) === 'Proxy') {
+            return substr($className, 0, -5);
+        }
+
+        return $className;
+    }
+
+    /**
      * Checks if object has identifier already in unit of work.
      *
-     * @param string $reference
+     * @param object $reference
      *
      * @return bool
      */

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -143,7 +143,7 @@ class ReferenceRepository
      *
      * @return void
      */
-    public function setReferenceIdentity($name, $identity, $class = null)
+    public function setReferenceIdentity($name, $identity, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -202,8 +202,7 @@ class ReferenceRepository
      * Loads an object using stored reference
      * named by $name
      *
-     * @param string      $name
-     * @param string|null $class
+     * @param string $name
      * @psalm-param class-string<T>|null $class
      *
      * @return object
@@ -213,7 +212,7 @@ class ReferenceRepository
      *
      * @template T of object
      */
-    public function getReference($name, $class = null)
+    public function getReference($name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -259,13 +258,12 @@ class ReferenceRepository
      * Check if an object is stored using reference
      * named by $name
      *
-     * @param string      $name
-     * @param string|null $class
+     * @param string $name
      * @psalm-param class-string $class
      *
      * @return bool
      */
-    public function hasReference($name, $class = null)
+    public function hasReference($name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -307,7 +305,7 @@ class ReferenceRepository
      *
      * @return bool
      */
-    public function hasIdentity($name, $class = null)
+    public function hasIdentity($name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Common\DataFixtures;
 
 use BadMethodCallException;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\PHPCR\DocumentManager as PhpcrDocumentManager;
 use Doctrine\Persistence\ObjectManager;
 use OutOfBoundsException;
@@ -24,7 +25,7 @@ class ReferenceRepository
 {
     /**
      * List of named references to the fixture objects
-     * gathered during loads of fixtures
+     * gathered during fixure loading
      *
      * @psalm-var array<string, object>
      */
@@ -32,7 +33,7 @@ class ReferenceRepository
 
     /**
      * List of named references to the fixture objects
-     * gathered during loads of fixtures
+     * gathered during fixure loading
      *
      * @psalm-var array<class-string, array<string, object>>
      */
@@ -40,7 +41,7 @@ class ReferenceRepository
 
     /**
      * List of identifiers stored for references
-     * in case if reference gets unmanaged, it will
+     * in case a reference gets no longer managed, it will
      * use a proxy referenced by this identity
      *
      * @psalm-var array<string, mixed>
@@ -49,7 +50,7 @@ class ReferenceRepository
 
     /**
      * List of identifiers stored for references
-     * in case if reference gets unmanaged, it will
+     * in case a reference gets no longer managed, it will
      * use a proxy referenced by this identity
      *
      * @psalm-var array<class-string, array<string, mixed>>
@@ -141,13 +142,15 @@ class ReferenceRepository
      *
      * @return void
      */
-    public function setReferenceIdentity($name, $identity, $class = null) // NEXT_MAJOR: Make $class mandatory
+    public function setReferenceIdentity($name, $identity, $class = null)
     {
         if ($class === null) {
-            @trigger_error(sprintf(
-                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+            Deprecation::trigger(
+                'doctrine/data-fixtures',
+                'https://github.com/doctrine/data-fixtures/pull/409',
+                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
         }
 
         $this->identitiesByClass[$class][$name] = $identity;
@@ -177,7 +180,7 @@ class ReferenceRepository
         // For BC, to be removed in next major.
         if (isset($this->references[$name])) {
             throw new BadMethodCallException(sprintf(
-                'Reference to "%s" already exists, use method setReference in order to override it',
+                'Reference to "%s" already exists, use method setReference() in order to override it',
                 $name
             ));
         }
@@ -185,7 +188,7 @@ class ReferenceRepository
         $class = $this->getRealClass(get_class($object));
         if (isset($this->referencesByClass[$class][$name])) {
             throw new BadMethodCallException(sprintf(
-                'Reference to "%s" for class "%s" already exists, use method setReference in order to override it',
+                'Reference to "%s" for class "%s" already exists, use method setReference() in order to override it',
                 $name,
                 $class
             ));
@@ -209,13 +212,15 @@ class ReferenceRepository
      *
      * @throws OutOfBoundsException - if repository does not exist.
      */
-    public function getReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
+    public function getReference($name, $class = null)
     {
         if ($class === null) {
-            @trigger_error(sprintf(
-                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+            Deprecation::trigger(
+                'doctrine/data-fixtures',
+                'https://github.com/doctrine/data-fixtures/pull/409',
+                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
         }
 
         if (! $this->hasReference($name, $class)) {
@@ -260,13 +265,15 @@ class ReferenceRepository
      *
      * @psalm-param class-string $class
      */
-    public function hasReference($name, $class = null) // NEXT_MAJOR: Make $class mandatory
+    public function hasReference($name, $class = null)
     {
         if ($class === null) {
-            @trigger_error(sprintf(
-                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+            Deprecation::trigger(
+                'doctrine/data-fixtures',
+                'https://github.com/doctrine/data-fixtures/pull/409',
+                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
         }
 
         return $class === null
@@ -300,13 +307,15 @@ class ReferenceRepository
      *
      * @return bool
      */
-    public function hasIdentity($name, $class = null) // NEXT_MAJOR: Make $class mandatory
+    public function hasIdentity($name, $class = null)
     {
         if ($class === null) {
-            @trigger_error(sprintf(
-                'Argument 3 of %s() will be mandatory in DoctrineDataFixtures 2.0.',
+            Deprecation::trigger(
+                'doctrine/data-fixtures',
+                'https://github.com/doctrine/data-fixtures/pull/409',
+                'Argument $class of %s() will be mandatory in DoctrineDataFixtures 2.0.',
                 __METHOD__
-            ), E_USER_DEPRECATED);
+            );
         }
 
         return $class === null
@@ -331,7 +340,7 @@ class ReferenceRepository
      *
      * @psalm-return array<class-string, array<string, object>>
      */
-    public function getIdentitiesByClass()
+    public function getIdentitiesByClass(): array
     {
         return $this->identitiesByClass;
     }
@@ -353,7 +362,7 @@ class ReferenceRepository
      *
      * @psalm-return array<class-string, array<string, object>>
      */
-    public function getReferencesByClass()
+    public function getReferencesByClass(): array
     {
         return $this->referencesByClass;
     }

--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -15,6 +15,7 @@ use function array_keys;
 use function get_class;
 use function method_exists;
 use function sprintf;
+use function substr;
 
 /**
  * ReferenceRepository class manages references for
@@ -201,16 +202,16 @@ class ReferenceRepository
      * Loads an object using stored reference
      * named by $name
      *
-     * @param string $name
+     * @param string      $name
      * @param string|null $class
+     * @psalm-param class-string<T>|null $class
      *
      * @return object
-     *
-     * @template T of object
-     * @psalm-param class-string<T>|null $class
      * @psalm-return $class is null ? object : T
      *
      * @throws OutOfBoundsException - if repository does not exist.
+     *
+     * @template T of object
      */
     public function getReference($name, $class = null)
     {
@@ -258,12 +259,11 @@ class ReferenceRepository
      * Check if an object is stored using reference
      * named by $name
      *
-     * @param string $name
+     * @param string      $name
      * @param string|null $class
+     * @psalm-param class-string $class
      *
      * @return bool
-     *
-     * @psalm-param class-string $class
      */
     public function hasReference($name, $class = null)
     {
@@ -292,7 +292,7 @@ class ReferenceRepository
     public function getReferenceNames($reference)
     {
         $class = $this->getRealClass(get_class($reference));
-        if (!isset($this->referencesByClass[$class])) {
+        if (! isset($this->referencesByClass[$class])) {
             return [];
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32,7 +32,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getReference\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php
 
 		-
@@ -114,4 +114,3 @@ parameters:
 			message: "#^Call to an undefined method Doctrine\\\\ODM\\\\MongoDB\\\\DocumentManager\\:\\:getConnection\\(\\)\\.$#"
 			count: 1
 			path: tests/Doctrine/Tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
-

--- a/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -134,7 +134,7 @@ class ReferenceRepositoryTest extends BaseTest
 
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(
-            'Reference to "duplicated_reference" already exists, use method setReference in order to override it'
+            'Reference to "duplicated_reference" already exists, use method setReference() in order to override it'
         );
 
         $referenceRepository->addReference('duplicated_reference', new stdClass());


### PR DESCRIPTION
Hi @greg0ire 

Closes https://github.com/doctrine/data-fixtures/issues/408

I introduce a `$class` param in a BC way:
- If you use it, phpstan/psalm understand the return type
- If you don't use it, it still works.

In next major, the idea would be to make the class param mandatory.
This way, having two fixtures with the same name but different class would be allowed.