### PR TITLE
Fix reference update

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -247,8 +247,9 @@ class ReferenceRepository
         $meta = $this->manager->getClassMetadata($class);
 
         if (! $this->manager->contains($reference) && $identity !== null) {
-            $reference               = $this->manager->getReference($meta->name, $identity);
-            $this->references[$name] = $reference; // already in identity map
+            $reference                              = $this->manager->getReference($meta->name, $identity);
+            $this->references[$name]                = $reference; // already in identity map
+            $this->referencesByClass[$class][$name] = $reference; // already in identity map
         }
 
         return $reference;


### PR DESCRIPTION
Related to https://github.com/doctrine/data-fixtures/pull/409 (cc @greg0ire)
 
When the manager does not contains the reference of an object and need to update it, 
`$this->references[$name]` was updated but not `$this->referencesByClass[$class][$name]`.

This PR fix this.