### PR TITLE
Drop support for doctrine/persistence 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "doctrine/persistence": "^1.3.3|^2.0|^3.0"
+        "doctrine/persistence": "^2.0|^3.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.13",

--- a/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
+++ b/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php
@@ -13,7 +13,6 @@ use Doctrine\Persistence\ObjectManager;
 use Exception;
 
 use function get_class;
-use function interface_exists;
 use function sprintf;
 
 /**
@@ -157,5 +156,3 @@ abstract class AbstractExecutor
      */
     abstract public function execute(array $fixtures, $append = false);
 }
-
-interface_exists(ObjectManager::class);

--- a/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
+++ b/lib/Doctrine/Common/DataFixtures/FixtureInterface.php
@@ -6,8 +6,6 @@ namespace Doctrine\Common\DataFixtures;
 
 use Doctrine\Persistence\ObjectManager;
 
-use function interface_exists;
-
 /**
  * Interface contract for fixture classes to implement.
  */
@@ -18,5 +16,3 @@ interface FixtureInterface
      */
     public function load(ObjectManager $manager);
 }
-
-interface_exists(ObjectManager::class);


### PR DESCRIPTION
This allows us to drop the Voodoo incantations described in https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf