### PR TITLE
Use a more accurate type 

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -47,7 +47,7 @@ class Loader
     /**
      * Array of ordered fixture object instances.
      *
-     * @psalm-var array<class-string<OrderedFixtureInterface>, OrderedFixtureInterface>|list<OrderedFixtureInterface>
+     * @psalm-var array<class-string<FixtureInterface>|int, FixtureInterface>
      */
     private $orderedFixtures = [];
 
@@ -181,7 +181,7 @@ class Loader
     /**
      * Returns the array of data fixtures to execute.
      *
-     * @psalm-return array<class-string<OrderedFixtureInterface>|int, OrderedFixtureInterface>
+     * @psalm-return array<class-string<FixtureInterface>|int, FixtureInterface>
      */
     public function getFixtures()
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: lib/Doctrine/Common/DataFixtures/Loader.php
 
 		-
-			message: "#^Property Doctrine\\\\Common\\\\DataFixtures\\\\Loader\\:\\:\\$orderedFixtures \\(array\\<class\\-string\\<Doctrine\\\\Common\\\\DataFixtures\\\\OrderedFixtureInterface\\>\\|int, Doctrine\\\\Common\\\\DataFixtures\\\\OrderedFixtureInterface\\>\\) does not accept array\\<class\\-string\\<Doctrine\\\\Common\\\\DataFixtures\\\\FixtureInterface\\>, Doctrine\\\\Common\\\\DataFixtures\\\\FixtureInterface\\>\\.$#"
-			count: 2
-			path: lib/Doctrine/Common/DataFixtures/Loader.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getReference\\(\\)\\.$#"
 			count: 2
 			path: lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php


### PR DESCRIPTION
`getFixtures()` doesn't always return instances of `OrderedFixtureInterface`
(for instance if you don't use those at all).

Fixes #414 , and should also fix the build of the bundle (see https://github.com/doctrine/DoctrineFixturesBundle/pull/375 for an example of a broken build)