### PR TITLE
Fix phpdoc of `Loader::getFixtures`

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Loader.php
+++ b/lib/Doctrine/Common/DataFixtures/Loader.php
@@ -47,7 +47,7 @@ class Loader
     /**
      * Array of ordered fixture object instances.
      *
-     * @psalm-var array<class-string<OrderedFixtureInterface>, OrderedFixtureInterface>|list<OrderedFixtureInterface>
+     * @psalm-var array<class-string<FixtureInterface>|int, FixtureInterface>
      */
     private $orderedFixtures = [];
 
@@ -181,7 +181,7 @@ class Loader
     /**
      * Returns the array of data fixtures to execute.
      *
-     * @psalm-return array<class-string<OrderedFixtureInterface>|int, OrderedFixtureInterface>
+     * @psalm-return array<class-string<FixtureInterface>|int, FixtureInterface>
      */
     public function getFixtures()
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: lib/Doctrine/Common/DataFixtures/Loader.php
 
 		-
-			message: "#^Property Doctrine\\\\Common\\\\DataFixtures\\\\Loader\\:\\:\\$orderedFixtures \\(array\\<class\\-string\\<Doctrine\\\\Common\\\\DataFixtures\\\\OrderedFixtureInterface\\>\\|int, Doctrine\\\\Common\\\\DataFixtures\\\\OrderedFixtureInterface\\>\\) does not accept array\\<class\\-string\\<Doctrine\\\\Common\\\\DataFixtures\\\\FixtureInterface\\>, Doctrine\\\\Common\\\\DataFixtures\\\\FixtureInterface\\>\\.$#"
-			count: 2
-			path: lib/Doctrine/Common/DataFixtures/Loader.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getReference\\(\\)\\.$#"
 			count: 2
 			path: lib/Doctrine/Common/DataFixtures/ProxyReferenceRepository.php


### PR DESCRIPTION
The fixtures are not necessarily instances of `OrderedFixtureInterface`

Triggered by https://github.com/doctrine/DoctrineMongoDBBundle/actions/runs/3824815692/jobs/6507341290#step:6:16