### PR TITLE
Update ReferenceRepository::getRealClass() to match with doctrine\common

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
+++ b/lib/Doctrine/Common/DataFixtures/ReferenceRepository.php
@@ -8,6 +8,7 @@ use BadMethodCallException;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ODM\PHPCR\DocumentManager as PhpcrDocumentManager;
 use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\Proxy;
 use OutOfBoundsException;
 
 use function array_key_exists;
@@ -15,6 +16,7 @@ use function array_keys;
 use function get_class;
 use function method_exists;
 use function sprintf;
+use function strrpos;
 use function substr;
 
 /**
@@ -385,11 +387,13 @@ class ReferenceRepository
      */
     protected function getRealClass($className)
     {
-        if (substr($className, -5) === 'Proxy') {
-            return substr($className, 0, -5);
+        $pos = strrpos($className, '\\' . Proxy::MARKER . '\\');
+
+        if ($pos === false) {
+            return $className;
         }
 
-        return $className;
+        return substr($className, $pos + Proxy::MARKER_LENGTH + 2);
     }
 
     /**

--- a/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -212,4 +212,22 @@ class ReferenceRepositoryTest extends BaseTest
 
         $this->assertEquals($identitiesExpected, $identities['entity']);
     }
+
+    public function testReferenceEntityWithSuffixProxy(): void
+    {
+        $em                  = $this->getMockSqliteEntityManager();
+        $referenceRepository = new ReferenceRepository($em);
+        $em->getEventManager()->addEventSubscriber(new ORMReferenceListener($referenceRepository));
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->createSchema([$em->getClassMetadata(TestEntity\EntityWithSuffixProxy::class)]);
+
+        $entity = new TestEntity\EntityWithSuffixProxy();
+
+        $em->persist($entity);
+        $referenceRepository->addReference('admin', $entity);
+        $em->flush();
+        $em->clear();
+
+        $this->assertInstanceOf(Proxy::class, $referenceRepository->getReference('admin'));
+    }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/EntityWithSuffixProxy.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/TestEntity/EntityWithSuffixProxy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class EntityWithSuffixProxy
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     *
+     * @var int|null
+     */
+    private $id;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Fixes #417.

This fixes ReferenceRepository::getRealClass() to match with the behaviour of the equiavlent function in doctrine\common ClassUtils::getRealClass().