### PR TITLE
Fix conditional typehints

### DIFF
--- a/src/AbstractFixture.php
+++ b/src/AbstractFixture.php
@@ -85,7 +85,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      * @psalm-param class-string<T>|null $class
      *
      * @return object
-     * @psalm-return $class is null ? object : T
+     * @psalm-return ($class is null ? object : T)
      *
      * @template T of object
      */

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -205,7 +205,7 @@ class ReferenceRepository
      * @psalm-param class-string<T>|null $class
      *
      * @return object
-     * @psalm-return $class is null ? object : T
+     * @psalm-return ($class is null ? object : T)
      *
      * @throws OutOfBoundsException - if repository does not exist.
      *


### PR DESCRIPTION
According to Psalm [docs](https://psalm.dev/docs/annotating_code/type_syntax/conditional_types/) all conditional types must be wrapped inside brackets