### PR TITLE
doctrine/deprecations is a mandatory dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "doctrine/persistence": "^1.3.3|^2.0|^3.0"
+        "doctrine/deprecations": "^0.5.3 || ^1.0",
+        "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.13",
@@ -26,7 +27,6 @@
         "ext-sqlite3": "*",
         "doctrine/coding-standard": "^11.0",
         "doctrine/dbal": "^2.13 || ^3.0",
-        "doctrine/deprecations": "^1.0",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
         "doctrine/orm": "^2.12",
         "phpstan/phpstan": "^1.5",


### PR DESCRIPTION
We trigger deprecations from non-test classes and need the Doctrine deprecations library for that. Because of that, it has to be a mandatory dependency.

This change probably doesn't make that much of a difference because data fixtures is most likely used in projects that depend on other libraries that pull the `doctrine/deprecations` dependency already, like DBAL or ORM.