### PR TITLE
Modernize codebase for PHP 7.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,15 +25,14 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
         include:
-          - php-version: "7.2"
+          - php-version: "7.4"
             dependencies: "lowest"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -14,25 +14,25 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "doctrine/persistence": "^2.0|^3.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.13",
-        "doctrine/orm": "<2.12",
+        "doctrine/orm": "<2.13",
         "doctrine/phpcr-odm": "<1.3.0"
     },
     "require-dev": {
         "ext-sqlite3": "*",
-        "doctrine/coding-standard": "^11.0",
+        "doctrine/coding-standard": "^11.1",
         "doctrine/dbal": "^2.13 || ^3.0",
         "doctrine/deprecations": "^1.0",
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
-        "doctrine/orm": "^2.12",
-        "phpstan/phpstan": "^1.5",
-        "phpunit/phpunit": "^8.5 || ^9.5 || ^10.0",
-        "symfony/cache": "^5.0 || ^6.0",
-        "vimeo/psalm": "^4.10 || ^5.9"
+        "doctrine/orm": "^2.13",
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^9.6.6 || ^10.0",
+        "symfony/cache": "^5.4 || ^6.2",
+        "vimeo/psalm": "^5.9"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
     <arg name="cache" value=".phpcs-cache"/>
     <arg name="colors" />
 
-    <config name="php_version" value="70200"/>
+    <config name="php_version" value="70400"/>
 
     <!-- Ignore warnings and show progress of the run -->
     <arg value="nps"/>
@@ -19,10 +19,6 @@
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
-
-        <!-- Will cause BC breaks to method signatures - disabled for now -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint"/>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
@@ -45,6 +41,24 @@
         <exclude-pattern>src/Purger/PurgerInterface.php</exclude-pattern>
         <exclude-pattern>src/OrderedFixtureInterface.php</exclude-pattern>
         <exclude-pattern>src/SharedFixtureInterface.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
+        <!-- Adding parameter types is a BC break in most cases because of strict types. -->
+        <exclude-pattern>src/*</exclude-pattern>
+
+        <!-- Don't add parameter types to overridden methods -->
+        <exclude-pattern>tests/Common/DataFixtures/TestTypes/UuidType.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
+        <!-- Adding property types is a BC break in most cases. -->
+        <exclude-pattern>src/*</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
+        <!-- Adding return types is a BC break in most cases. -->
+        <exclude-pattern>src/*</exclude-pattern>
     </rule>
 
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -102,7 +102,7 @@ parameters:
 
 		-
 			message: "#^Method Doctrine\\\\Tests\\\\Common\\\\DataFixtures\\\\Executor\\\\PHPCRExecutorTest\\:\\:getDocumentManager\\(\\) has invalid return type Doctrine\\\\ODM\\\\PHPCR\\\\DocumentManager\\.$#"
-			count: 1
+			count: 2
 			path: tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.22.0@fc2c6ab4d5fa5d644d8617089f012f3bb84b8703">
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="src/Executor/PHPCRExecutor.php">
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
+      <code>DocumentManagerInterface</code>
       <code>DocumentManagerInterface</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="2">
-      <code>DocumentManagerInterface</code>
+    <UndefinedDocblockClass>
       <code>DocumentManagerInterface</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/Purger/PHPCRPurger.php">
-    <UndefinedClass occurrences="3">
+    <UndefinedClass>
+      <code><![CDATA[$this->dm]]></code>
+      <code>?DocumentManagerInterface</code>
       <code>?DocumentManagerInterface</code>
       <code>DocumentManager</code>
       <code>NodeHelper</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="3">
-      <code>$this-&gt;dm</code>
-      <code>DocumentManagerInterface|null</code>
+    <UndefinedDocblockClass>
       <code>DocumentManagerInterface|null</code>
     </UndefinedDocblockClass>
   </file>
   <file src="src/ReferenceRepository.php">
-    <UndefinedClass occurrences="2">
+    <UndefinedClass>
       <code>PhpcrDocumentManager</code>
       <code>PhpcrDocumentManager</code>
     </UndefinedClass>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    phpVersion="7.4"
+    phpVersion="8.2"
     errorLevel="7"
     findUnusedBaselineEntry="true"
     findUnusedCode="false"

--- a/src/AbstractFixture.php
+++ b/src/AbstractFixture.php
@@ -96,7 +96,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
                 'Argument $class of %s() will be mandatory in 2.0.',
-                __METHOD__
+                __METHOD__,
             );
         }
 
@@ -121,7 +121,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
                 'Argument $class of %s() will be mandatory in 2.0.',
-                __METHOD__
+                __METHOD__,
             );
         }
 

--- a/src/Event/Listener/MongoDBReferenceListener.php
+++ b/src/Event/Listener/MongoDBReferenceListener.php
@@ -16,8 +16,7 @@ use function get_class;
  */
 final class MongoDBReferenceListener implements EventSubscriber
 {
-    /** @var ReferenceRepository */
-    private $referenceRepository;
+    private ReferenceRepository $referenceRepository;
 
     public function __construct(ReferenceRepository $referenceRepository)
     {
@@ -27,17 +26,15 @@ final class MongoDBReferenceListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return ['postPersist'];
     }
 
     /**
      * Populates identities for stored references
-     *
-     * @return void
      */
-    public function postPersist(LifecycleEventArgs $args)
+    public function postPersist(LifecycleEventArgs $args): void
     {
         $object = $args->getDocument();
 

--- a/src/Event/Listener/ORMReferenceListener.php
+++ b/src/Event/Listener/ORMReferenceListener.php
@@ -16,8 +16,7 @@ use function get_class;
  */
 final class ORMReferenceListener implements EventSubscriber
 {
-    /** @var ReferenceRepository */
-    private $referenceRepository;
+    private ReferenceRepository $referenceRepository;
 
     public function __construct(ReferenceRepository $referenceRepository)
     {
@@ -27,7 +26,7 @@ final class ORMReferenceListener implements EventSubscriber
     /**
      * {@inheritdoc}
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         // would be better to use onClear, but it is supported only in 2.1
         return ['postPersist'];
@@ -35,10 +34,8 @@ final class ORMReferenceListener implements EventSubscriber
 
     /**
      * Populates identities for stored references
-     *
-     * @return void
      */
-    public function postPersist(LifecycleEventArgs $args)
+    public function postPersist(LifecycleEventArgs $args): void
     {
         $object = $args->getEntity();
 

--- a/src/Executor/AbstractExecutor.php
+++ b/src/Executor/AbstractExecutor.php
@@ -135,7 +135,7 @@ abstract class AbstractExecutor
         if ($this->purger === null) {
             throw new Exception(
                 PurgerInterface::class .
-                 ' instance is required if you want to purge the database before loading your data fixtures.'
+                 ' instance is required if you want to purge the database before loading your data fixtures.',
             );
         }
 
@@ -154,5 +154,5 @@ abstract class AbstractExecutor
      *
      * @return void
      */
-    abstract public function execute(array $fixtures, $append = false);
+    abstract public function execute(array $fixtures, bool $append = false);
 }

--- a/src/Executor/MongoDBExecutor.php
+++ b/src/Executor/MongoDBExecutor.php
@@ -14,11 +14,8 @@ use Doctrine\ODM\MongoDB\DocumentManager;
  */
 class MongoDBExecutor extends AbstractExecutor
 {
-    /** @var DocumentManager */
-    private $dm;
-
-    /** @var MongoDBReferenceListener */
-    private $listener;
+    private DocumentManager $dm;
+    private MongoDBReferenceListener $listener;
 
     /**
      * Construct new fixtures loader instance.
@@ -54,7 +51,7 @@ class MongoDBExecutor extends AbstractExecutor
     {
         $this->dm->getEventManager()->removeEventListener(
             $this->listener->getSubscribedEvents(),
-            $this->listener
+            $this->listener,
         );
 
         $this->referenceRepository = $referenceRepository;

--- a/src/Executor/MultipleTransactionORMExecutor.php
+++ b/src/Executor/MultipleTransactionORMExecutor.php
@@ -15,15 +15,11 @@ final class MultipleTransactionORMExecutor extends AbstractExecutor
     {
         $executor = $this;
         if ($append === false) {
-            $this->em->wrapInTransaction(static function () use ($executor) {
-                $executor->purge();
-            });
+            $this->em->wrapInTransaction(static fn () => $executor->purge());
         }
 
         foreach ($fixtures as $fixture) {
-            $this->em->wrapInTransaction(static function (EntityManagerInterface $em) use ($executor, $fixture) {
-                $executor->load($em, $fixture);
-            });
+            $this->em->wrapInTransaction(static fn (EntityManagerInterface $em) => $executor->load($em, $fixture));
         }
     }
 }

--- a/src/Executor/ORMExecutorCommon.php
+++ b/src/Executor/ORMExecutorCommon.php
@@ -15,13 +15,10 @@ use Doctrine\ORM\EntityManagerInterface;
 trait ORMExecutorCommon
 {
     /** @var EntityManager|EntityManagerDecorator */
-    private $em;
+    private EntityManagerInterface $em;
 
-    /** @var EntityManagerInterface */
-    private $originalManager;
-
-    /** @var ORMReferenceListener */
-    private $listener;
+    private EntityManagerInterface $originalManager;
+    private ORMReferenceListener $listener;
 
     public function __construct(EntityManagerInterface $em, ?ORMPurgerInterface $purger = null)
     {
@@ -59,7 +56,7 @@ trait ORMExecutorCommon
     {
         $this->em->getEventManager()->removeEventListener(
             $this->listener->getSubscribedEvents(),
-            $this->listener
+            $this->listener,
         );
 
         parent::setReferenceRepository($referenceRepository);

--- a/src/Executor/PHPCRExecutor.php
+++ b/src/Executor/PHPCRExecutor.php
@@ -14,8 +14,7 @@ use function method_exists;
  */
 class PHPCRExecutor extends AbstractExecutor
 {
-    /** @var DocumentManagerInterface */
-    private $dm;
+    private DocumentManagerInterface $dm;
 
     /**
      * @param DocumentManagerInterface $dm     manager instance used for persisting the fixtures

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -42,35 +42,29 @@ class Loader
      *
      * @psalm-var array<class-string<FixtureInterface>, FixtureInterface>
      */
-    private $fixtures = [];
+    private array $fixtures = [];
 
     /**
      * Array of ordered fixture object instances.
      *
      * @psalm-var array<class-string<FixtureInterface>|int, FixtureInterface>
      */
-    private $orderedFixtures = [];
+    private array $orderedFixtures = [];
 
     /**
      * Determines if we must order fixtures by number
-     *
-     * @var bool
      */
-    private $orderFixturesByNumber = false;
+    private bool $orderFixturesByNumber = false;
 
     /**
      * Determines if we must order fixtures by its dependencies
-     *
-     * @var bool
      */
-    private $orderFixturesByDependencies = false;
+    private bool $orderFixturesByDependencies = false;
 
     /**
      * The file extension of fixture files.
-     *
-     * @var string
      */
-    private $fileExtension = '.php';
+    private string $fileExtension = '.php';
 
     /**
      * Find fixtures classes in a given directory and load them.
@@ -87,7 +81,7 @@ class Loader
 
         $iterator = new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator($dir),
-            RecursiveIteratorIterator::LEAVES_ONLY
+            RecursiveIteratorIterator::LEAVES_ONLY,
         );
 
         return $this->loadFromIterator($iterator);
@@ -135,7 +129,7 @@ class Loader
         if (! isset($this->fixtures[$className])) {
             throw new InvalidArgumentException(sprintf(
                 '"%s" is not a registered fixture',
-                $className
+                $className,
             ));
         }
 
@@ -158,7 +152,7 @@ class Loader
                 'Class "%s" can\'t implement "%s" and "%s" at the same time.',
                 get_class($fixture),
                 'OrderedFixtureInterface',
-                'DependentFixtureInterface'
+                'DependentFixtureInterface',
             ));
         }
 
@@ -308,14 +302,14 @@ class Loader
                     throw new InvalidArgumentException(sprintf(
                         'Method "%s" in class "%s" must return an array of classes which are dependencies for the fixture, and it must be NOT empty.',
                         'getDependencies',
-                        $fixtureClass
+                        $fixtureClass,
                     ));
                 }
 
                 if (in_array($fixtureClass, $dependenciesClasses)) {
                     throw new InvalidArgumentException(sprintf(
                         'Class "%s" can\'t have itself as a dependency',
-                        $fixtureClass
+                        $fixtureClass,
                     ));
                 }
 
@@ -380,7 +374,7 @@ class Loader
             if (! in_array($class, $loadedFixtureClasses)) {
                 throw new RuntimeException(sprintf(
                     'Fixture "%s" was declared as a dependency, but it should be added in fixture loader first.',
-                    $class
+                    $class,
                 ));
             }
         }

--- a/src/ProxyReferenceRepository.php
+++ b/src/ProxyReferenceRepository.php
@@ -62,8 +62,8 @@ class ProxyReferenceRepository extends ReferenceRepository
                     $name,
                     $this->getManager()->getReference(
                         $proxyReference[0], // entity class name
-                        $proxyReference[1]  // identifiers
-                    )
+                        $proxyReference[1],  // identifiers
+                    ),
                 );
             }
 
@@ -82,8 +82,8 @@ class ProxyReferenceRepository extends ReferenceRepository
                     $name,
                     $this->getManager()->getReference(
                         $className,
-                        $identity
-                    )
+                        $identity,
+                    ),
                 );
 
                 $this->setReferenceIdentity($name, $identity, $className);

--- a/src/Purger/MongoDBPurger.php
+++ b/src/Purger/MongoDBPurger.php
@@ -11,8 +11,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
  */
 class MongoDBPurger implements PurgerInterface
 {
-    /** @var DocumentManager|null */
-    private $dm;
+    private ?DocumentManager $dm;
 
     /**
      * Construct new purger instance.

--- a/src/Purger/ORMPurger.php
+++ b/src/Purger/ORMPurger.php
@@ -26,8 +26,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
     public const PURGE_MODE_DELETE   = 1;
     public const PURGE_MODE_TRUNCATE = 2;
 
-    /** @var EntityManagerInterface|null */
-    private $em;
+    private ?EntityManagerInterface $em;
 
     /**
      * If the purge should be done through DELETE or TRUNCATE statements
@@ -41,7 +40,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
      *
      * @var string[]
      */
-    private $excluded;
+    private array $excluded;
 
     /**
      * Construct new purger instance.
@@ -132,13 +131,13 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
         $connection            = $this->em->getConnection();
         $filterExpr            = method_exists(
             $connection->getConfiguration(),
-            'getFilterSchemaAssetsExpression'
+            'getFilterSchemaAssetsExpression',
         ) ? $connection->getConfiguration()->getFilterSchemaAssetsExpression() : null;
         $emptyFilterExpression = empty($filterExpr);
 
         $schemaAssetsFilter = method_exists(
             $connection->getConfiguration(),
-            'getSchemaAssetsFilter'
+            'getSchemaAssetsFilter',
         ) ? $connection->getConfiguration()->getSchemaAssetsFilter() : null;
 
         foreach ($orderedTables as $tbl) {

--- a/src/Purger/PHPCRPurger.php
+++ b/src/Purger/PHPCRPurger.php
@@ -13,8 +13,7 @@ use PHPCR\Util\NodeHelper;
  */
 class PHPCRPurger implements PurgerInterface
 {
-    /** @var DocumentManagerInterface|null */
-    private $dm;
+    private ?DocumentManagerInterface $dm;
 
     public function __construct(?DocumentManagerInterface $dm = null)
     {

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -29,7 +29,7 @@ class ReferenceRepository
      *
      * @psalm-var array<string, object>
      */
-    private $references = [];
+    private array $references = [];
 
     /**
      * List of named references to the fixture objects
@@ -37,7 +37,7 @@ class ReferenceRepository
      *
      * @psalm-var array<class-string, array<string, object>>
      */
-    private $referencesByClass = [];
+    private array $referencesByClass = [];
 
     /**
      * List of identifiers stored for references
@@ -46,7 +46,7 @@ class ReferenceRepository
      *
      * @psalm-var array<string, mixed>
      */
-    private $identities = [];
+    private array $identities = [];
 
     /**
      * List of identifiers stored for references
@@ -55,14 +55,12 @@ class ReferenceRepository
      *
      * @psalm-var array<class-string, array<string, mixed>>
      */
-    private $identitiesByClass = [];
+    private array $identitiesByClass = [];
 
     /**
      * Currently used object manager
-     *
-     * @var ObjectManager
      */
-    private $manager;
+    private ObjectManager $manager;
 
     public function __construct(ObjectManager $manager)
     {
@@ -149,7 +147,7 @@ class ReferenceRepository
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
                 'Argument $class of %s() will be mandatory in 2.0.',
-                __METHOD__
+                __METHOD__,
             );
         }
 
@@ -181,7 +179,7 @@ class ReferenceRepository
         if (isset($this->references[$name])) {
             throw new BadMethodCallException(sprintf(
                 'Reference to "%s" already exists, use method setReference() in order to override it',
-                $name
+                $name,
             ));
         }
 
@@ -190,7 +188,7 @@ class ReferenceRepository
             throw new BadMethodCallException(sprintf(
                 'Reference to "%s" for class "%s" already exists, use method setReference() in order to override it',
                 $name,
-                $class
+                $class,
             ));
         }
 
@@ -218,7 +216,7 @@ class ReferenceRepository
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
                 'Argument $class of %s() will be mandatory in 2.0.',
-                __METHOD__
+                __METHOD__,
             );
         }
 
@@ -270,7 +268,7 @@ class ReferenceRepository
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
                 'Argument $class of %s() will be mandatory in 2.0.',
-                __METHOD__
+                __METHOD__,
             );
         }
 
@@ -312,7 +310,7 @@ class ReferenceRepository
                 'doctrine/data-fixtures',
                 'https://github.com/doctrine/data-fixtures/pull/409',
                 'Argument $class of %s() will be mandatory in 2.0.',
-                __METHOD__
+                __METHOD__,
             );
         }
 

--- a/src/Sorter/TopologicalSorter.php
+++ b/src/Sorter/TopologicalSorter.php
@@ -29,26 +29,24 @@ class TopologicalSorter
      *
      * @var Vertex[]
      */
-    private $nodeList = [];
+    private array $nodeList = [];
 
     /**
      * Volatile variable holding calculated nodes during sorting process.
      *
      * @var ClassMetadata[]
      */
-    private $sortedNodeList = [];
+    private array $sortedNodeList = [];
 
     /**
      * Allow or not cyclic dependencies
-     *
-     * @var bool
      */
-    private $allowCyclicDependencies;
+    private bool $allowCyclicDependencies;
 
     /** @param bool $allowCyclicDependencies */
     public function __construct($allowCyclicDependencies = true)
     {
-        $this->allowCyclicDependencies = $allowCyclicDependencies;
+        $this->allowCyclicDependencies = (bool) $allowCyclicDependencies;
     }
 
     /**
@@ -138,7 +136,7 @@ class TopologicalSorter
                 throw new RuntimeException(sprintf(
                     'Fixture "%s" has a dependency of fixture "%s", but it not listed to be loaded.',
                     get_class($definition->value),
-                    $dependency
+                    $dependency,
                 ));
             }
 
@@ -164,8 +162,8 @@ Finally, class A has class C as its dependency.
 EXCEPTION
                                 ,
                                 $definition->value->getName(),
-                                $childDefinition->value->getName()
-                            )
+                                $childDefinition->value->getName(),
+                            ),
                         );
                     }
 

--- a/src/Sorter/Vertex.php
+++ b/src/Sorter/Vertex.php
@@ -18,14 +18,18 @@ class Vertex
     public const IN_PROGRESS = 1;
     public const VISITED     = 2;
 
-    /** @var int one of either {@see self::NOT_VISITED}, {@see self::IN_PROGRESS} or {@see self::VISITED}. */
-    public $state = self::NOT_VISITED;
+    /** @psalm-var self::* */
+    public int $state = self::NOT_VISITED;
 
-    /** @var ClassMetadata Actual node value */
-    public $value;
+    /** Actual node value. */
+    public ClassMetadata $value;
 
-    /** @var string[] Map of node dependencies defined as hashes. */
-    public $dependencyList = [];
+    /**
+     * Map of node dependencies defined as hashes.
+     *
+     * @var string[]
+     */
+    public array $dependencyList = [];
 
     public function __construct(ClassMetadata $value)
     {

--- a/tests/Common/DataFixtures/BaseTestCase.php
+++ b/tests/Common/DataFixtures/BaseTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\DataFixtures;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use PHPUnit\Framework\TestCase;
@@ -16,29 +17,25 @@ abstract class BaseTestCase extends TestCase
     /**
      * EntityManager mock object together with
      * annotation mapping driver
-     *
-     * @return EntityManager
      */
-    protected function getMockAnnotationReaderEntityManager()
+    protected function getMockAnnotationReaderEntityManager(): EntityManager
     {
         $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
         $config   = ORMSetup::createAnnotationMetadataConfiguration([__DIR__ . '/TestEntity'], true);
 
-        return EntityManager::create($dbParams, $config);
+        return new EntityManager(DriverManager::getConnection($dbParams, $config), $config);
     }
 
     /**
      * EntityManager mock object together with
      * annotation mapping driver and pdo_sqlite
      * database in memory
-     *
-     * @return EntityManager
      */
-    protected function getMockSqliteEntityManager()
+    protected function getMockSqliteEntityManager(): EntityManager
     {
         $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
         $config   = ORMSetup::createAnnotationMetadataConfiguration([__DIR__ . '/TestEntity'], true);
 
-        return EntityManager::create($dbParams, $config);
+        return new EntityManager(DriverManager::getConnection($dbParams, $config), $config);
     }
 }

--- a/tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
+++ b/tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
@@ -120,13 +120,13 @@ class PHPCRExecutorTest extends BaseTestCase
     }
 
     /** @return PHPCRPurger&MockObject */
-    private function getPurger()
+    private function getPurger(): PHPCRPurger
     {
         return $this->createMock(PHPCRPurger::class);
     }
 
     /** @return DocumentManager&MockObject */
-    private function getDocumentManager()
+    private function getDocumentManager(): DocumentManager
     {
         if (! class_exists(DocumentManager::class)) {
             $this->markTestSkipped('Missing doctrine/phpcr-odm');
@@ -144,7 +144,7 @@ class PHPCRExecutorTest extends BaseTestCase
     }
 
     /** @return FixtureInterface&MockObject */
-    private function getMockFixture()
+    private function getMockFixture(): FixtureInterface
     {
         return $this->createMock(FixtureInterface::class);
     }

--- a/tests/Common/DataFixtures/FixtureTest.php
+++ b/tests/Common/DataFixtures/FixtureTest.php
@@ -24,8 +24,7 @@ class FixtureTest extends BaseTestCase
 
 class MyFixture2 implements FixtureInterface
 {
-    /** @var bool */
-    public $loaded = false;
+    public bool $loaded = false;
 
     public function load(ObjectManager $manager): void
     {

--- a/tests/Common/DataFixtures/LoaderTest.php
+++ b/tests/Common/DataFixtures/LoaderTest.php
@@ -21,7 +21,7 @@ class LoaderTest extends BaseTestCase
         $loader->addFixture($this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock1')->getMock());
         $loader->addFixture($this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock2')->getMock());
         $loader->addFixture(
-            $this->getMockBuilder(SharedFixtureInterface::class)->setMockClassName('Mock3')->getMock()
+            $this->getMockBuilder(SharedFixtureInterface::class)->setMockClassName('Mock3')->getMock(),
         );
 
         $this->assertCount(3, $loader->getFixtures());
@@ -38,7 +38,7 @@ class LoaderTest extends BaseTestCase
         $loader->addFixture($this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock1')->getMock());
         $loader->addFixture($this->getMockBuilder(FixtureInterface::class)->setMockClassName('Mock2')->getMock());
         $loader->addFixture(
-            $this->getMockBuilder(SharedFixtureInterface::class)->setMockClassName('Mock3')->getMock()
+            $this->getMockBuilder(SharedFixtureInterface::class)->setMockClassName('Mock3')->getMock(),
         );
 
         $this->assertCount(3, $loader->getFixtures());

--- a/tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
+++ b/tests/Common/DataFixtures/ProxyReferenceRepositoryTest.php
@@ -58,7 +58,7 @@ class ProxyReferenceRepositoryTest extends BaseTestCase
             ->setConstructorArgs([$em])
             ->getMock();
         $em->getEventManager()->addEventSubscriber(
-            new ORMReferenceListener($referenceRepository)
+            new ORMReferenceListener($referenceRepository),
         );
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema([]);
@@ -154,7 +154,7 @@ class ProxyReferenceRepositoryTest extends BaseTestCase
 
         $this->assertInstanceOf(
             'Doctrine\Tests\Common\DataFixtures\TestValueObjects\Uuid',
-            $proxyReferenceRepository->getReference('home-link')->getId()
+            $proxyReferenceRepository->getReference('home-link')->getId(),
         );
     }
 

--- a/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -72,7 +72,7 @@ class MongoDBPurgerTest extends BaseTestCase
     }
 
     /** @param Collection|MongoCollection $collection */
-    private function assertIndexCount(int $expectedCount, $collection): void
+    private function assertIndexCount(int $expectedCount, object $collection): void
     {
         if ($collection instanceof Collection) {
             $indexes = $collection->listIndexes();

--- a/tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Common\DataFixtures;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -23,10 +24,8 @@ class ORMPurgerExcludeTest extends BaseTestCase
 
     /**
      * Loads test data
-     *
-     * @return EntityManager
      */
-    protected function loadTestData()
+    protected function loadTestData(): EntityManager
     {
         if (! extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped('Missing pdo_sqlite extension.');
@@ -34,7 +33,7 @@ class ORMPurgerExcludeTest extends BaseTestCase
 
         $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
         $config   = ORMSetup::createAnnotationMetadataConfiguration([__DIR__ . '/../TestPurgeEntity'], true);
-        $em       = EntityManager::create($dbParams, $config);
+        $em       = new EntityManager(DriverManager::getConnection($dbParams, $config), $config);
 
         $connection    = $em->getConnection();
         $configuration = $connection->getConfiguration();
@@ -65,10 +64,9 @@ class ORMPurgerExcludeTest extends BaseTestCase
     /**
      * Execute test purge
      *
-     * @param string|null $expression
-     * @param string[]    $list
+     * @param string[] $list
      */
-    public function executeTestPurge($expression, array $list, ?callable $filter = null): void
+    public function executeTestPurge(?string $expression, array $list, ?callable $filter = null): void
     {
         $em                 = $this->loadTestData();
         $excludedRepository = $em->getRepository(self::TEST_ENTITY_EXCLUDED);

--- a/tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -45,7 +45,7 @@ class ReferenceRepositoryTest extends BaseTestCase
             ->setConstructorArgs([$em])
             ->getMock();
         $em->getEventManager()->addEventSubscriber(
-            new ORMReferenceListener($referenceRepository)
+            new ORMReferenceListener($referenceRepository),
         );
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema([]);
@@ -74,7 +74,7 @@ class ReferenceRepositoryTest extends BaseTestCase
         $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ReferenceRepository($em);
         $em->getEventManager()->addEventSubscriber(
-            new ORMReferenceListener($referenceRepository)
+            new ORMReferenceListener($referenceRepository),
         );
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema([]);
@@ -135,7 +135,7 @@ class ReferenceRepositoryTest extends BaseTestCase
 
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(
-            'Reference to "duplicated_reference" already exists, use method setReference() in order to override it'
+            'Reference to "duplicated_reference" already exists, use method setReference() in order to override it',
         );
 
         $referenceRepository->addReference('duplicated_reference', new Role());

--- a/tests/Common/DataFixtures/TestDocument/Role.php
+++ b/tests/Common/DataFixtures/TestDocument/Role.php
@@ -9,20 +9,14 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /** @ODM\Document */
 class Role
 {
-    /**
-     * @ODM\Id
-     *
-     * @var string|null
-     */
-    private $id;
+    /** @ODM\Id */
+    private ?string $id = null;
 
     /**
      * @ODM\Field(type="string")
      * @ODM\Index
-     *
-     * @var string|null
      */
-    private $name;
+    private ?string $name = null;
 
     public function getId(): ?string
     {

--- a/tests/Common/DataFixtures/TestEntity/Group.php
+++ b/tests/Common/DataFixtures/TestEntity/Group.php
@@ -12,18 +12,14 @@ class Group
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     *
-     * @var int|null
      */
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)
      * @ORM\Id
-     *
-     * @var string|null
      */
-    private $code;
+    private ?string $code = null;
 
     public function setId(int $id): void
     {

--- a/tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
+++ b/tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
@@ -15,18 +15,14 @@ class GroupWithSchema
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     *
-     * @var int|null
      */
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)
      * @ORM\Id
-     *
-     * @var string|null
      */
-    private $code;
+    private ?string $code = null;
 
     public function setId(int $id): void
     {

--- a/tests/Common/DataFixtures/TestEntity/Link.php
+++ b/tests/Common/DataFixtures/TestEntity/Link.php
@@ -13,17 +13,11 @@ class Link
     /**
      * @ORM\Id
      * @ORM\Column(type="uuid")
-     *
-     * @var Uuid
      */
-    private $id;
+    private Uuid $id;
 
-    /**
-     * @ORM\Column(length=150)
-     *
-     * @var string|null
-     */
-    private $url;
+    /** @ORM\Column(length=150) */
+    private ?string $url = null;
 
     public function __construct(Uuid $id)
     {

--- a/tests/Common/DataFixtures/TestEntity/Quoted.php
+++ b/tests/Common/DataFixtures/TestEntity/Quoted.php
@@ -17,17 +17,11 @@ class Quoted
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
-     *
-     * @var int|null
      */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @ORM\Column(length=50, name="select")
-     *
-     * @var string|null
-     */
-    private $select;
+    /** @ORM\Column(length=50, name="select") */
+    private ?string $select = null;
 
     /**
      * @ORM\ManyToMany(targetEntity=Quoted::class)
@@ -38,7 +32,7 @@ class Quoted
      *
      * @var Collection|null
      */
-    private $selects;
+    private ?Collection $selects = null;
 
     public function getId(): ?int
     {

--- a/tests/Common/DataFixtures/TestEntity/Role.php
+++ b/tests/Common/DataFixtures/TestEntity/Role.php
@@ -13,17 +13,11 @@ class Role
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
-     *
-     * @var int|null
      */
-    private $id;
+    private ?int $id = null;
 
-    /**
-     * @ORM\Column(length=50)
-     *
-     * @var string|null
-     */
-    private $name;
+    /** @ORM\Column(length=50) */
+    private ?string $name = null;
 
     public function getId(): ?int
     {

--- a/tests/Common/DataFixtures/TestEntity/User.php
+++ b/tests/Common/DataFixtures/TestEntity/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -15,39 +16,23 @@ class User
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     *
-     * @var int|null
      */
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)
      * @ORM\Id
-     *
-     * @var string|null
      */
-    private $code;
+    private ?string $code = null;
 
-    /**
-     * @ORM\Column(length=32)
-     *
-     * @var string|null
-     */
-    private $password;
+    /** @ORM\Column(length=32) */
+    private ?string $password = null;
 
-    /**
-     * @ORM\Column(length=255)
-     *
-     * @var string|null
-     */
-    private $email;
+    /** @ORM\Column(length=255) */
+    private ?string $email = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity=Role::class, cascade={"persist"})
-     *
-     * @var Role|null
-     */
-    private $role;
+    /** @ORM\ManyToOne(targetEntity=Role::class, cascade={"persist"}) */
+    private ?Role $role = null;
 
     /**
      * @ORM\ManyToMany(targetEntity=User::class, inversedBy="authors")
@@ -56,16 +41,22 @@ class User
      *      inverseJoinColumns={@ORM\JoinColumn(name="reader_id", referencedColumnName="id")}
      * )
      *
-     * @var User[]|Collection
+     * @var Collection<int, User>
      */
-    private $readers;
+    private Collection $readers;
 
     /**
      * @ORM\ManyToMany(targetEntity=User::class, mappedBy="readers")
      *
-     * @var User[]|Collection
+     * @var Collection<int, User>
      */
-    private $authors;
+    private Collection $authors;
+
+    public function __construct()
+    {
+        $this->readers = new ArrayCollection();
+        $this->authors = new ArrayCollection();
+    }
 
     public function setId(int $id): void
     {
@@ -117,36 +108,36 @@ class User
         return $this->role;
     }
 
-    /** @return User[]|Collection */
-    public function getReaders()
+    /** @return Collection<int, User> */
+    public function getReaders(): Collection
     {
         return $this->readers;
     }
 
     /**
-     * @param User[]|Collection $readers
+     * @param Collection<int, User> $readers
      *
-     * @return User
+     * @return $this
      */
-    public function setReaders($readers)
+    public function setReaders(Collection $readers): self
     {
         $this->readers = $readers;
 
         return $this;
     }
 
-    /** @return User[]|Collection */
-    public function getAuthors()
+    /** @return Collection<int, User> */
+    public function getAuthors(): Collection
     {
         return $this->authors;
     }
 
     /**
-     * @param User[]|Collection $authors
+     * @param Collection<int, User> $authors
      *
-     * @return User
+     * @return $this
      */
-    public function setAuthors($authors)
+    public function setAuthors(Collection $authors): self
     {
         $this->authors = $authors;
 

--- a/tests/Common/DataFixtures/TestEntity/UserWithSchema.php
+++ b/tests/Common/DataFixtures/TestEntity/UserWithSchema.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\DataFixtures\TestEntity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -18,39 +19,23 @@ class UserWithSchema
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     *
-     * @var int|null
      */
-    private $id;
+    private ?int $id = null;
 
     /**
      * @ORM\Column(length=32)
      * @ORM\Id
-     *
-     * @var string|null
      */
-    private $code;
+    private ?string $code = null;
 
-    /**
-     * @ORM\Column(length=32)
-     *
-     * @var string|null
-     */
-    private $password;
+    /** @ORM\Column(length=32) */
+    private ?string $password = null;
 
-    /**
-     * @ORM\Column(length=255)
-     *
-     * @var string|null
-     */
-    private $email;
+    /** @ORM\Column(length=255) */
+    private ?string $email = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity=Role::class, cascade={"persist"})
-     *
-     * @var Role|null
-     */
-    private $role;
+    /** @ORM\ManyToOne(targetEntity=Role::class, cascade={"persist"}) */
+    private ?Role $role = null;
 
     /**
      * @ORM\ManyToMany(targetEntity=UserWithSchema::class, inversedBy="authors")
@@ -59,16 +44,22 @@ class UserWithSchema
      *      inverseJoinColumns={@ORM\JoinColumn(name="reader_id", referencedColumnName="id")}
      * )
      *
-     * @psalm-var Collection<int, self>
+     * @var Collection<int, self>
      */
-    private $readers;
+    private Collection $readers;
 
     /**
      * @ORM\ManyToMany(targetEntity=UserWithSchema::class, mappedBy="readers")
      *
-     * @psalm-var Collection<int, self>
+     * @var Collection<int, self>
      */
-    private $authors;
+    private Collection $authors;
+
+    public function __construct()
+    {
+        $this->readers = new ArrayCollection();
+        $this->authors = new ArrayCollection();
+    }
 
     public function setId(int $id): void
     {
@@ -120,28 +111,36 @@ class UserWithSchema
         return $this->role;
     }
 
-    /** @psalm-return Collection<int, self> */
+    /** @return Collection<int, self> */
     public function getReaders(): Collection
     {
         return $this->readers;
     }
 
-    /** @psalm-param Collection<int, self> $readers */
-    public function setReaders($readers): self
+    /**
+     * @param Collection<int, self> $readers
+     *
+     * @return $this
+     */
+    public function setReaders(Collection $readers): self
     {
         $this->readers = $readers;
 
         return $this;
     }
 
-    /** @psalm-return Collection<int, self> */
-    public function getAuthors()
+    /** @return Collection<int, self> */
+    public function getAuthors(): Collection
     {
         return $this->authors;
     }
 
-    /** @param Collection<int, self> $authors */
-    public function setAuthors($authors): self
+    /**
+     * @param Collection<int, self> $authors
+     *
+     * @return $this
+     */
+    public function setAuthors(Collection $authors): self
     {
         $this->authors = $authors;
 

--- a/tests/Common/DataFixtures/TestFixtures/RoleFixture.php
+++ b/tests/Common/DataFixtures/TestFixtures/RoleFixture.php
@@ -11,8 +11,7 @@ use Doctrine\Tests\Common\DataFixtures\TestEntity\Role;
 
 class RoleFixture implements SharedFixtureInterface
 {
-    /** @var ReferenceRepository|null */
-    private $referenceRepository;
+    private ?ReferenceRepository $referenceRepository = null;
 
     public function setReferenceRepository(ReferenceRepository $referenceRepository): void
     {

--- a/tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
+++ b/tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
@@ -12,10 +12,8 @@ class ExcludedEntity
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     *
-     * @var int
      */
-    private $id;
+    private ?int $id = null;
 
     public function setId(int $id): void
     {

--- a/tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
+++ b/tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
@@ -12,10 +12,8 @@ class IncludedEntity
     /**
      * @ORM\Column(type="integer")
      * @ORM\Id
-     *
-     * @var int
      */
-    private $id;
+    private ?int $id = null;
 
     public function setId(int $id): void
     {

--- a/tests/Common/DataFixtures/TestTypes/UuidType.php
+++ b/tests/Common/DataFixtures/TestTypes/UuidType.php
@@ -21,13 +21,13 @@ class UuidType extends Type
         return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
     }
 
-    /** @param ?string $value */
+    /** @param string|null $value */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?Uuid
     {
         return $value === null ? null : new Uuid($value);
     }
 
-    /** @param ?Uuid $value */
+    /** @param Uuid|null $value */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         return $value === null ? null : (string) $value;

--- a/tests/Common/DataFixtures/TestValueObjects/Uuid.php
+++ b/tests/Common/DataFixtures/TestValueObjects/Uuid.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Common\DataFixtures\TestValueObjects;
 
 use JsonSerializable;
-use Serializable;
 
-class Uuid implements JsonSerializable, Serializable
+class Uuid implements JsonSerializable
 {
-    /** @var string $id */
-    private $id;
+    private string $id;
 
     public function __construct(string $id)
     {
@@ -25,17 +23,6 @@ class Uuid implements JsonSerializable, Serializable
     public function jsonSerialize(): string
     {
         return $this->id;
-    }
-
-    public function serialize(): string
-    {
-        return $this->id;
-    }
-
-    /** @param string $serialized */
-    public function unserialize($serialized): void
-    {
-        $this->id = $serialized;
     }
 
     public function __serialize(): array


### PR DESCRIPTION
Seems like nobody uses this library on PHP 7.2/7.3 anymore these days, so let's make our lives a bit easier by dropping support for those versions. I also took the liberty to add native types where it's not a breaking change.