### PR TITLE
Added test showing the issue when fixture depends on ordered fixture

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -403,7 +403,7 @@ class Loader
         }
 
         foreach ($classes as $class) {
-            if ($sequences[$class] !== -1) {
+            if (! isset($sequences[$class]) || $sequences[$class] !== -1) {
                 continue;
             }
 


### PR DESCRIPTION
This test shows the issue described in #148.

The error handler has to be replaced for the test, because otherwise the code works and the deprecation for the undefined array key does not show up.

Closes #198