### PR TITLE
Replace call to deprecated `LifecycleEventArgs::getEntityManager()`

### DIFF
--- a/src/Event/Listener/ORMReferenceListener.php
+++ b/src/Event/Listener/ORMReferenceListener.php
@@ -48,7 +48,7 @@ final class ORMReferenceListener implements EventSubscriber
         }
 
         foreach ($names as $name) {
-            $identity = $args->getEntityManager()
+            $identity = $args->getObjectManager()
                 ->getUnitOfWork()
                 ->getEntityIdentifier($object);
 


### PR DESCRIPTION
Similar to #444 but now replacing `getEntityManager()` with `getObjectManager()`.