### PR TITLE
Add parameter types

### DIFF
--- a/src/AbstractFixture.php
+++ b/src/AbstractFixture.php
@@ -49,7 +49,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @return void
      */
-    public function setReference(string $name, $object)
+    public function setReference(string $name, object $object)
     {
         $this->getReferenceRepository()->setReference($name, $object);
     }
@@ -106,7 +106,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::hasReference
      *
-     * @psalm-param class-string $class
+     * @psalm-param class-string|null $class
      *
      * @return bool
      */

--- a/src/AbstractFixture.php
+++ b/src/AbstractFixture.php
@@ -45,12 +45,11 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::setReference
      *
-     * @param string $name
      * @param object $object - managed object
      *
      * @return void
      */
-    public function setReference($name, $object)
+    public function setReference(string $name, $object)
     {
         $this->getReferenceRepository()->setReference($name, $object);
     }
@@ -63,14 +62,13 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::addReference
      *
-     * @param string $name
      * @param object $object - managed object
      *
      * @return void
      *
      * @throws BadMethodCallException - if repository already has a reference by $name.
      */
-    public function addReference($name, $object)
+    public function addReference(string $name, object $object)
     {
         $this->getReferenceRepository()->addReference($name, $object);
     }
@@ -81,7 +79,6 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::getReference
      *
-     * @param string $name
      * @psalm-param class-string<T>|null $class
      *
      * @return object
@@ -89,7 +86,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @template T of object
      */
-    public function getReference($name, ?string $class = null)
+    public function getReference(string $name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -109,12 +106,11 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @see Doctrine\Common\DataFixtures\ReferenceRepository::hasReference
      *
-     * @param string $name
      * @psalm-param class-string $class
      *
      * @return bool
      */
-    public function hasReference($name, ?string $class = null)
+    public function hasReference(string $name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(

--- a/src/Executor/AbstractExecutor.php
+++ b/src/Executor/AbstractExecutor.php
@@ -76,11 +76,9 @@ abstract class AbstractExecutor
     /**
      * Set the logger callable to execute with the log() method.
      *
-     * @param callable $logger
-     *
      * @return void
      */
-    public function setLogger($logger)
+    public function setLogger(callable $logger)
     {
         $this->logger = $logger;
     }
@@ -88,11 +86,9 @@ abstract class AbstractExecutor
     /**
      * Logs a message using the logger.
      *
-     * @param string $message
-     *
      * @return void
      */
-    public function log($message)
+    public function log(string $message)
     {
         $logger = $this->logger;
         $logger($message);

--- a/src/Executor/MongoDBExecutor.php
+++ b/src/Executor/MongoDBExecutor.php
@@ -60,7 +60,7 @@ class MongoDBExecutor extends AbstractExecutor
     }
 
     /** @inheritDoc */
-    public function execute(array $fixtures, $append = false)
+    public function execute(array $fixtures, bool $append = false)
     {
         if ($append === false) {
             $this->purge();

--- a/src/Executor/MultipleTransactionORMExecutor.php
+++ b/src/Executor/MultipleTransactionORMExecutor.php
@@ -11,7 +11,7 @@ final class MultipleTransactionORMExecutor extends AbstractExecutor
     use ORMExecutorCommon;
 
     /** @inheritDoc */
-    public function execute(array $fixtures, $append = false): void
+    public function execute(array $fixtures, bool $append = false): void
     {
         $executor = $this;
         if ($append === false) {

--- a/src/Executor/ORMExecutor.php
+++ b/src/Executor/ORMExecutor.php
@@ -14,7 +14,7 @@ class ORMExecutor extends AbstractExecutor
     use ORMExecutorCommon;
 
     /** @inheritDoc */
-    public function execute(array $fixtures, $append = false)
+    public function execute(array $fixtures, bool $append = false)
     {
         $executor = $this;
         $this->em->wrapInTransaction(static function (EntityManagerInterface $em) use ($executor, $fixtures, $append) {

--- a/src/Executor/PHPCRExecutor.php
+++ b/src/Executor/PHPCRExecutor.php
@@ -40,7 +40,7 @@ class PHPCRExecutor extends AbstractExecutor
     }
 
     /** @inheritDoc */
-    public function execute(array $fixtures, $append = false)
+    public function execute(array $fixtures, bool $append = false)
     {
         $that = $this;
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -73,7 +73,7 @@ class Loader
      *
      * @return array $fixtures Array of loaded fixture object instances.
      */
-    public function loadFromDirectory($dir)
+    public function loadFromDirectory(string $dir)
     {
         if (! is_dir($dir)) {
             throw new InvalidArgumentException(sprintf('"%s" does not exist', $dir));
@@ -94,7 +94,7 @@ class Loader
      *
      * @return array $fixtures Array of loaded fixture object instances.
      */
-    public function loadFromFile($fileName)
+    public function loadFromFile(string $fileName)
     {
         if (! is_readable($fileName)) {
             throw new InvalidArgumentException(sprintf('"%s" does not exist or is not readable', $fileName));
@@ -108,11 +108,9 @@ class Loader
     /**
      * Has fixture?
      *
-     * @param FixtureInterface $fixture
-     *
      * @return bool
      */
-    public function hasFixture($fixture)
+    public function hasFixture(FixtureInterface $fixture)
     {
         return isset($this->fixtures[get_class($fixture)]);
     }
@@ -120,11 +118,9 @@ class Loader
     /**
      * Get a specific fixture instance
      *
-     * @param string $className
-     *
      * @return FixtureInterface
      */
-    public function getFixture($className)
+    public function getFixture(string $className)
     {
         if (! isset($this->fixtures[$className])) {
             throw new InvalidArgumentException(sprintf(
@@ -204,7 +200,7 @@ class Loader
      *
      * @return bool
      */
-    public function isTransient($className)
+    public function isTransient(string $className)
     {
         $rc = new ReflectionClass($className);
         if ($rc->isAbstract()) {
@@ -219,11 +215,9 @@ class Loader
     /**
      * Creates the fixture object from the class.
      *
-     * @param string $class
-     *
      * @return FixtureInterface
      */
-    protected function createFixture($class)
+    protected function createFixture(string $class)
     {
         return new $class();
     }

--- a/src/ProxyReferenceRepository.php
+++ b/src/ProxyReferenceRepository.php
@@ -49,7 +49,7 @@ class ProxyReferenceRepository extends ReferenceRepository
      *
      * @return void
      */
-    public function unserialize($serializedData)
+    public function unserialize(string $serializedData)
     {
         $repositoryData = unserialize($serializedData);
 
@@ -98,7 +98,7 @@ class ProxyReferenceRepository extends ReferenceRepository
      *
      * @return bool
      */
-    public function load($baseCacheName)
+    public function load(string $baseCacheName)
     {
         $filename = $baseCacheName . '.ser';
 
@@ -124,7 +124,7 @@ class ProxyReferenceRepository extends ReferenceRepository
      *
      * @return void
      */
-    public function save($baseCacheName)
+    public function save(string $baseCacheName)
     {
         $serializedData = $this->serialize();
 

--- a/src/Purger/ORMPurger.php
+++ b/src/Purger/ORMPurger.php
@@ -59,11 +59,9 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
     /**
      * Set the purge mode
      *
-     * @param int $mode
-     *
      * @return void
      */
-    public function setPurgeMode($mode)
+    public function setPurgeMode(int $mode)
     {
         $this->purgeMode           = $mode;
         $this->cachedSqlStatements = null;

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -75,7 +75,7 @@ class ReferenceRepository
      *
      * @return array
      */
-    protected function getIdentifier($reference, $uow)
+    protected function getIdentifier(object $reference, object $uow)
     {
         // In case Reference is not yet managed in UnitOfWork
         if (! $this->hasIdentifier($reference)) {
@@ -103,12 +103,9 @@ class ReferenceRepository
      * and referenced to $reference. If $name
      * already is set, it overrides it
      *
-     * @param string $name
-     * @param object $reference
-     *
      * @return void
      */
-    public function setReference($name, $reference)
+    public function setReference(string $name, object $reference)
     {
         $class = $this->getRealClass(get_class($reference));
 
@@ -134,13 +131,12 @@ class ReferenceRepository
     /**
      * Store the identifier of a reference
      *
-     * @param string            $name
      * @param mixed             $identity
      * @param class-string|null $class
      *
      * @return void
      */
-    public function setReferenceIdentity($name, $identity, ?string $class = null)
+    public function setReferenceIdentity(string $name, $identity, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -166,14 +162,13 @@ class ReferenceRepository
      * the record is inserted, be sure tu use this method
      * after $object is flushed
      *
-     * @param string $name
      * @param object $object - managed object
      *
      * @return void
      *
      * @throws BadMethodCallException - if repository already has a reference by $name.
      */
-    public function addReference($name, $object)
+    public function addReference(string $name, object $object)
     {
         // For BC, to be removed in next major.
         if (isset($this->references[$name])) {
@@ -199,7 +194,6 @@ class ReferenceRepository
      * Loads an object using stored reference
      * named by $name
      *
-     * @param string $name
      * @psalm-param class-string<T>|null $class
      *
      * @return object
@@ -209,7 +203,7 @@ class ReferenceRepository
      *
      * @template T of object
      */
-    public function getReference($name, ?string $class = null)
+    public function getReference(string $name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -256,12 +250,11 @@ class ReferenceRepository
      * Check if an object is stored using reference
      * named by $name
      *
-     * @param string $name
      * @psalm-param class-string $class
      *
      * @return bool
      */
-    public function hasReference($name, ?string $class = null)
+    public function hasReference(string $name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -281,11 +274,9 @@ class ReferenceRepository
      * Searches for reference names in the
      * list of stored references
      *
-     * @param object $reference
-     *
      * @return array<string>
      */
-    public function getReferenceNames($reference)
+    public function getReferenceNames(object $reference)
     {
         $class = $this->getRealClass(get_class($reference));
         if (! isset($this->referencesByClass[$class])) {
@@ -298,12 +289,11 @@ class ReferenceRepository
     /**
      * Checks if reference has identity stored
      *
-     * @param string            $name
      * @param class-string|null $class
      *
      * @return bool
      */
-    public function hasIdentity($name, ?string $class = null)
+    public function hasIdentity(string $name, ?string $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -380,7 +370,7 @@ class ReferenceRepository
      *
      * @return string
      */
-    protected function getRealClass($className)
+    protected function getRealClass(string $className)
     {
         return $this->manager->getClassMetadata($className)->getName();
     }
@@ -388,11 +378,9 @@ class ReferenceRepository
     /**
      * Checks if object has identifier already in unit of work.
      *
-     * @param object $reference
-     *
      * @return bool
      */
-    private function hasIdentifier($reference)
+    private function hasIdentifier(object $reference)
     {
         // in case if reference is set after flush, store its identity
         $uow = $this->manager->getUnitOfWork();

--- a/src/Sorter/TopologicalSorter.php
+++ b/src/Sorter/TopologicalSorter.php
@@ -43,8 +43,7 @@ class TopologicalSorter
      */
     private bool $allowCyclicDependencies;
 
-    /** @param bool $allowCyclicDependencies */
-    public function __construct($allowCyclicDependencies = true)
+    public function __construct(bool $allowCyclicDependencies = true)
     {
         $this->allowCyclicDependencies = (bool) $allowCyclicDependencies;
     }
@@ -52,11 +51,9 @@ class TopologicalSorter
     /**
      * Adds a new node (vertex) to the graph, assigning its hash and value.
      *
-     * @param string $hash
-     *
      * @return void
      */
-    public function addNode($hash, ClassMetadata $node)
+    public function addNode(string $hash, ClassMetadata $node)
     {
         $this->nodeList[$hash] = new Vertex($node);
     }
@@ -64,11 +61,9 @@ class TopologicalSorter
     /**
      * Checks the existence of a node in the graph.
      *
-     * @param string $hash
-     *
      * @return bool
      */
-    public function hasNode($hash)
+    public function hasNode(string $hash)
     {
         return isset($this->nodeList[$hash]);
     }
@@ -76,12 +71,9 @@ class TopologicalSorter
     /**
      * Adds a new dependency (edge) to the graph using their hashes.
      *
-     * @param string $fromHash
-     * @param string $toHash
-     *
      * @return void
      */
-    public function addDependency($fromHash, $toHash)
+    public function addDependency(string $fromHash, string $toHash)
     {
         $definition = $this->nodeList[$fromHash];
 


### PR DESCRIPTION
In `DoctrineMongoDBBundle`, we can't add parameter types to all the classes because they are not defined in the base class or the interface. https://github.com/doctrine/DoctrineMongoDBBundle/pull/812/files#diff-1571e1997e046b65a3fdffae3826e46e2a5a89adcce01ff580557d7eedc536e1R71

Adding parameter types to all the methods should not be an issues for classes that extends them. But it might for interfaces.

Also upgrading to PHP 8.1 is required for some `mixed` and union types.