### PR TITLE
Reference classes using current namespace in `@see` phpdoc

### DIFF
--- a/src/AbstractFixture.php
+++ b/src/AbstractFixture.php
@@ -43,7 +43,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      * and referenced to managed $object. If $name
      * already is set, it overrides it
      *
-     * @see Doctrine\Common\DataFixtures\ReferenceRepository::setReference
+     * @see ReferenceRepository::setReference()
      *
      * @param string $name
      * @param object $object - managed object
@@ -61,7 +61,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      * already is set, it throws a
      * BadMethodCallException exception
      *
-     * @see Doctrine\Common\DataFixtures\ReferenceRepository::addReference
+     * @see ReferenceRepository::addReference()
      *
      * @param string $name
      * @param object $object - managed object
@@ -79,7 +79,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      * Loads an object using stored reference
      * named by $name
      *
-     * @see Doctrine\Common\DataFixtures\ReferenceRepository::getReference
+     * @see ReferenceRepository::getReference()
      *
      * @param string $name
      * @psalm-param class-string<T>|null $class
@@ -107,7 +107,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      * Check if an object is stored using reference
      * named by $name
      *
-     * @see Doctrine\Common\DataFixtures\ReferenceRepository::hasReference
+     * @see ReferenceRepository::hasReference()
      *
      * @param string $name
      * @psalm-param class-string $class

--- a/src/Sorter/Vertex.php
+++ b/src/Sorter/Vertex.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 /**
  * @internal this class is to be used only by data-fixtures internals: do not
  *           rely on it in your own libraries/applications. This class is
- *           designed to work with {@see \Doctrine\Common\DataFixtures\Sorter\TopologicalSorter}
+ *           designed to work with {@see TopologicalSorter}
  *           only.
  */
 class Vertex


### PR DESCRIPTION
Make `@see` references work (in PHPStorm at least).