### PR TITLE
Make Executor and Purger classes final

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,11 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 1.8
+
+Executor and Purger classes are final, they cannot be extended.
+`AbstractExecutor` is internal. It cannot be extended or used as typehint.
+
 # Upgrade to 1.6
 
 ## BC BREAK: `CircularReferenceException` no longer extends `Doctrine\Common\CommonException`

--- a/docs/en/explanation/transactions-and-purging.rst
+++ b/docs/en/explanation/transactions-and-purging.rst
@@ -1,9 +1,8 @@
 Transactions and purging
 ========================
 
-This package exposes an ``AbstractExecutor`` class and 3 concrete
-implementations for ``doctrine/orm``, ``doctrine/mongodb-odm`` and
-``doctrine/phpcr-odm``.
+This package provides executors for ``doctrine/orm``, ``doctrine/mongodb-odm``
+and ``doctrine/phpcr-odm``.
 
 The executors purge the database, then load the fixtures. The ORM
 implementation wraps these two steps in a database transaction, which

--- a/src/Executor/AbstractExecutor.php
+++ b/src/Executor/AbstractExecutor.php
@@ -17,6 +17,8 @@ use function sprintf;
 
 /**
  * Abstract fixture executor.
+ *
+ * @internal since 1.8.0
  */
 abstract class AbstractExecutor
 {

--- a/src/Executor/MongoDBExecutor.php
+++ b/src/Executor/MongoDBExecutor.php
@@ -11,6 +11,8 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 
 /**
  * Class responsible for executing data fixtures.
+ *
+ * @final since 1.8.0
  */
 class MongoDBExecutor extends AbstractExecutor
 {

--- a/src/Executor/ORMExecutor.php
+++ b/src/Executor/ORMExecutor.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Class responsible for executing data fixtures.
+ *
+ * @final since 1.8.0
  */
 class ORMExecutor extends AbstractExecutor
 {

--- a/src/Executor/PHPCRExecutor.php
+++ b/src/Executor/PHPCRExecutor.php
@@ -11,6 +11,8 @@ use function method_exists;
 
 /**
  * Class responsible for executing data fixtures.
+ *
+ * @final since 1.8.0
  */
 class PHPCRExecutor extends AbstractExecutor
 {

--- a/src/Purger/MongoDBPurger.php
+++ b/src/Purger/MongoDBPurger.php
@@ -8,6 +8,8 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 
 /**
  * Class responsible for purging databases of data before reloading data fixtures.
+ *
+ * @final since 1.8.0
  */
 class MongoDBPurger implements PurgerInterface
 {

--- a/src/Purger/ORMPurger.php
+++ b/src/Purger/ORMPurger.php
@@ -19,6 +19,8 @@ use function in_array;
 
 /**
  * Class responsible for purging databases of data before reloading data fixtures.
+ *
+ * @final since 1.8.0
  */
 class ORMPurger implements PurgerInterface, ORMPurgerInterface
 {

--- a/src/Purger/PHPCRPurger.php
+++ b/src/Purger/PHPCRPurger.php
@@ -10,6 +10,8 @@ use PHPCR\Util\NodeHelper;
 
 /**
  * Class responsible for purging databases of data before reloading data fixtures.
+ *
+ * @final since 1.8.0
  */
 class PHPCRPurger implements PurgerInterface
 {


### PR DESCRIPTION
By moving this classes to a soft `@final` in 1.8, we can make them hard `final` in 2.0 and add types to the properties.

We don't expect any further implementations to be created out of this package.

Related to this outdated PR preparing a v2 #290