### PR TITLE
Drop support for PHP 7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,8 +25,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
           - "8.1"
           - "8.2"
           - "8.3"
@@ -35,7 +33,7 @@ jobs:
         stability:
           - "stable"
         include:
-          - php-version: "7.4"
+          - php-version: "8.1"
             dependencies: "lowest"
             stability: "stable"
           - php-version: "8.3"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,10 @@ awareness about deprecated code.
 - Use of our low-overhead runtime deprecation API, details:
   https://github.com/doctrine/deprecations/
 
+# Upgrade to 2.0
+
+You need PHP 8.1 or newer to use this library. 
+
 # Upgrade to 1.8
 
 Executor and Purger classes are final, they cannot be extended.

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "doctrine/deprecations": "^0.5.3 || ^1.0",
-        "doctrine/persistence": "^2.0|^3.0"
+        "doctrine/persistence": "^3.1"
     },
     "conflict": {
         "doctrine/dbal": "<3.5 || >=5",
@@ -31,10 +31,10 @@
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
         "doctrine/orm": "^2.14 || ^3",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.6.13 || ^10.4.2",
-        "symfony/cache": "^5.4 || ^6.3 || ^7",
-        "symfony/var-exporter": "^5.4 || ^6.3 || ^7",
-        "vimeo/psalm": "^5.9"
+        "phpunit/phpunit": "^10.5.3",
+        "symfony/cache": "^6.4 || ^7",
+        "symfony/var-exporter": "^6.4 || ^7",
+        "vimeo/psalm": "^5.18"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
     <arg name="cache" value=".phpcs-cache"/>
     <arg name="colors" />
 
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80100"/>
 
     <!-- Ignore warnings and show progress of the run -->
     <arg value="nps"/>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,7 +17,7 @@ parameters:
 
 		-
 			message: "#^Property Doctrine\\\\Common\\\\DataFixtures\\\\Executor\\\\PHPCRExecutor\\:\\:\\$dm has unknown class Doctrine\\\\ODM\\\\PHPCR\\\\DocumentManagerInterface as its type\\.$#"
-			count: 1
+			count: 2
 			path: src/Executor/PHPCRExecutor.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
+<files psalm-version="5.18.0@b113f3ed0259fd6e212d87c3df80eec95a6abf19">
   <file src="src/Executor/PHPCRExecutor.php">
     <UndefinedClass>
-      <code>DocumentManagerInterface</code>
       <code>DocumentManagerInterface</code>
     </UndefinedClass>
     <UndefinedDocblockClass>
@@ -12,10 +11,9 @@
   <file src="src/Purger/PHPCRPurger.php">
     <UndefinedClass>
       <code><![CDATA[$this->dm]]></code>
-      <code>?DocumentManagerInterface</code>
-      <code>?DocumentManagerInterface</code>
       <code>DocumentManager</code>
       <code>NodeHelper</code>
+      <code>private</code>
     </UndefinedClass>
     <UndefinedDocblockClass>
       <code>DocumentManagerInterface|null</code>

--- a/src/AbstractFixture.php
+++ b/src/AbstractFixture.php
@@ -86,7 +86,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @template T of object
      */
-    public function getReference(string $name, ?string $class = null)
+    public function getReference(string $name, string|null $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -110,7 +110,7 @@ abstract class AbstractFixture implements SharedFixtureInterface
      *
      * @return bool
      */
-    public function hasReference(string $name, ?string $class = null)
+    public function hasReference(string $name, string|null $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(

--- a/src/Event/Listener/MongoDBReferenceListener.php
+++ b/src/Event/Listener/MongoDBReferenceListener.php
@@ -8,19 +8,14 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\Event\LifecycleEventArgs;
 
-use function get_class;
-
 /**
  * Reference Listener populates identities for
  * stored references
  */
 final class MongoDBReferenceListener implements EventSubscriber
 {
-    private ReferenceRepository $referenceRepository;
-
-    public function __construct(ReferenceRepository $referenceRepository)
+    public function __construct(private ReferenceRepository $referenceRepository)
     {
-        $this->referenceRepository = $referenceRepository;
     }
 
     /**
@@ -48,7 +43,7 @@ final class MongoDBReferenceListener implements EventSubscriber
                 ->getUnitOfWork()
                 ->getDocumentIdentifier($object);
 
-            $this->referenceRepository->setReferenceIdentity($name, $identity, get_class($object));
+            $this->referenceRepository->setReferenceIdentity($name, $identity, $object::class);
         }
     }
 }

--- a/src/Event/Listener/ORMReferenceListener.php
+++ b/src/Event/Listener/ORMReferenceListener.php
@@ -8,19 +8,14 @@ use Doctrine\Common\DataFixtures\ReferenceRepository;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\PostPersistEventArgs;
 
-use function get_class;
-
 /**
  * Reference Listener populates identities for
  * stored references
  */
 final class ORMReferenceListener implements EventSubscriber
 {
-    private ReferenceRepository $referenceRepository;
-
-    public function __construct(ReferenceRepository $referenceRepository)
+    public function __construct(private ReferenceRepository $referenceRepository)
     {
-        $this->referenceRepository = $referenceRepository;
     }
 
     /**
@@ -49,7 +44,7 @@ final class ORMReferenceListener implements EventSubscriber
                 ->getUnitOfWork()
                 ->getEntityIdentifier($object);
 
-            $this->referenceRepository->setReferenceIdentity($name, $identity, get_class($object));
+            $this->referenceRepository->setReferenceIdentity($name, $identity, $object::class);
         }
     }
 }

--- a/src/Executor/AbstractExecutor.php
+++ b/src/Executor/AbstractExecutor.php
@@ -12,7 +12,6 @@ use Doctrine\Common\DataFixtures\SharedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Exception;
 
-use function get_class;
 use function sprintf;
 
 /**
@@ -109,7 +108,7 @@ abstract class AbstractExecutor
                 $prefix = sprintf('[%d] ', $fixture->getOrder());
             }
 
-            $this->log('loading ' . $prefix . get_class($fixture));
+            $this->log('loading ' . $prefix . $fixture::class);
         }
 
         // additionally pass the instance of reference repository to shared fixtures

--- a/src/Executor/MongoDBExecutor.php
+++ b/src/Executor/MongoDBExecutor.php
@@ -16,7 +16,6 @@ use Doctrine\ODM\MongoDB\DocumentManager;
  */
 class MongoDBExecutor extends AbstractExecutor
 {
-    private DocumentManager $dm;
     private MongoDBReferenceListener $listener;
 
     /**
@@ -24,9 +23,8 @@ class MongoDBExecutor extends AbstractExecutor
      *
      * @param DocumentManager $dm DocumentManager instance used for persistence.
      */
-    public function __construct(DocumentManager $dm, ?MongoDBPurger $purger = null)
+    public function __construct(private DocumentManager $dm, MongoDBPurger|null $purger = null)
     {
-        $this->dm = $dm;
         if ($purger !== null) {
             $this->purger = $purger;
             $this->purger->setDocumentManager($dm);

--- a/src/Executor/ORMExecutorCommon.php
+++ b/src/Executor/ORMExecutorCommon.php
@@ -20,7 +20,7 @@ trait ORMExecutorCommon
     private EntityManagerInterface $originalManager;
     private ORMReferenceListener $listener;
 
-    public function __construct(EntityManagerInterface $em, ?ORMPurgerInterface $purger = null)
+    public function __construct(EntityManagerInterface $em, ORMPurgerInterface|null $purger = null)
     {
         $this->originalManager = $em;
         // Make sure, wrapInTransaction() exists on the EM.

--- a/src/Executor/PHPCRExecutor.php
+++ b/src/Executor/PHPCRExecutor.php
@@ -16,17 +16,14 @@ use function method_exists;
  */
 class PHPCRExecutor extends AbstractExecutor
 {
-    private DocumentManagerInterface $dm;
-
     /**
      * @param DocumentManagerInterface $dm     manager instance used for persisting the fixtures
      * @param PHPCRPurger|null         $purger to remove the current data if append is false
      */
-    public function __construct(DocumentManagerInterface $dm, ?PHPCRPurger $purger = null)
+    public function __construct(private DocumentManagerInterface $dm, PHPCRPurger|null $purger = null)
     {
         parent::__construct($dm);
 
-        $this->dm = $dm;
         if ($purger === null) {
             return;
         }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -20,7 +20,6 @@ use function asort;
 use function class_exists;
 use function class_implements;
 use function count;
-use function get_class;
 use function get_declared_classes;
 use function implode;
 use function in_array;
@@ -112,7 +111,7 @@ class Loader
      */
     public function hasFixture(FixtureInterface $fixture)
     {
-        return isset($this->fixtures[get_class($fixture)]);
+        return isset($this->fixtures[$fixture::class]);
     }
 
     /**
@@ -137,7 +136,7 @@ class Loader
      */
     public function addFixture(FixtureInterface $fixture)
     {
-        $fixtureClass = get_class($fixture);
+        $fixtureClass = $fixture::class;
 
         if (isset($this->fixtures[$fixtureClass])) {
             return;
@@ -146,7 +145,7 @@ class Loader
         if ($fixture instanceof OrderedFixtureInterface && $fixture instanceof DependentFixtureInterface) {
             throw new InvalidArgumentException(sprintf(
                 'Class "%s" can\'t implement "%s" and "%s" at the same time.',
-                get_class($fixture),
+                $fixture::class,
                 'OrderedFixtureInterface',
                 'DependentFixtureInterface',
             ));
@@ -281,7 +280,7 @@ class Loader
 
         // First we determine which classes has dependencies and which don't
         foreach ($this->fixtures as $fixture) {
-            $fixtureClass = get_class($fixture);
+            $fixtureClass = $fixture::class;
 
             if ($fixture instanceof OrderedFixtureInterface) {
                 continue;
@@ -382,7 +381,7 @@ class Loader
      *
      * @psalm-return array<class-string<FixtureInterface>>
      */
-    private function getUnsequencedClasses(array $sequences, ?iterable $classes = null): array
+    private function getUnsequencedClasses(array $sequences, iterable|null $classes = null): array
     {
         $unsequencedClasses = [];
 

--- a/src/ProxyReferenceRepository.php
+++ b/src/ProxyReferenceRepository.php
@@ -7,7 +7,6 @@ namespace Doctrine\Common\DataFixtures;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
-use function get_class;
 use function serialize;
 use function unserialize;
 
@@ -30,7 +29,7 @@ class ProxyReferenceRepository extends ReferenceRepository
         $simpleReferences = [];
 
         foreach ($this->getReferences() as $name => $reference) {
-            $className = $this->getRealClass(get_class($reference));
+            $className = $this->getRealClass($reference::class);
 
             $simpleReferences[$name] = [$className, $this->getIdentifier($reference, $unitOfWork)];
         }

--- a/src/Purger/MongoDBPurger.php
+++ b/src/Purger/MongoDBPurger.php
@@ -13,16 +13,13 @@ use Doctrine\ODM\MongoDB\DocumentManager;
  */
 class MongoDBPurger implements PurgerInterface
 {
-    private ?DocumentManager $dm;
-
     /**
      * Construct new purger instance.
      *
      * @param DocumentManager|null $dm DocumentManager instance used for persistence.
      */
-    public function __construct(?DocumentManager $dm = null)
+    public function __construct(private DocumentManager|null $dm = null)
     {
-        $this->dm = $dm;
     }
 
     /**

--- a/src/Purger/ORMPurger.php
+++ b/src/Purger/ORMPurger.php
@@ -27,8 +27,6 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
     public const PURGE_MODE_DELETE   = 1;
     public const PURGE_MODE_TRUNCATE = 2;
 
-    private ?EntityManagerInterface $em;
-
     /**
      * If the purge should be done through DELETE or TRUNCATE statements
      *
@@ -44,7 +42,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
     private array $excluded;
 
     /** @var list<string>|null */
-    private ?array $cachedSqlStatements = null;
+    private array|null $cachedSqlStatements = null;
 
     /**
      * Construct new purger instance.
@@ -52,9 +50,8 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
      * @param EntityManagerInterface|null $em       EntityManagerInterface instance used for persistence.
      * @param string[]                    $excluded array of table/view names to be excluded from purge
      */
-    public function __construct(?EntityManagerInterface $em = null, array $excluded = [])
+    public function __construct(private EntityManagerInterface|null $em = null, array $excluded = [])
     {
-        $this->em       = $em;
         $this->excluded = $excluded;
     }
 
@@ -261,7 +258,7 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
     private function getJoinTableName(
         $assoc,
         ClassMetadata $class,
-        AbstractPlatform $platform
+        AbstractPlatform $platform,
     ): string {
         return $this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);
     }

--- a/src/Purger/PHPCRPurger.php
+++ b/src/Purger/PHPCRPurger.php
@@ -15,11 +15,8 @@ use PHPCR\Util\NodeHelper;
  */
 class PHPCRPurger implements PurgerInterface
 {
-    private ?DocumentManagerInterface $dm;
-
-    public function __construct(?DocumentManagerInterface $dm = null)
+    public function __construct(private DocumentManagerInterface|null $dm = null)
     {
-        $this->dm = $dm;
     }
 
     public function setDocumentManager(DocumentManager $dm)

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -13,7 +13,6 @@ use OutOfBoundsException;
 
 use function array_key_exists;
 use function array_keys;
-use function get_class;
 use function sprintf;
 
 /**
@@ -79,7 +78,7 @@ class ReferenceRepository
     {
         // In case Reference is not yet managed in UnitOfWork
         if (! $this->hasIdentifier($reference)) {
-            $class = $this->manager->getClassMetadata(get_class($reference));
+            $class = $this->manager->getClassMetadata($reference::class);
 
             return $class->getIdentifierValues($reference);
         }
@@ -107,7 +106,7 @@ class ReferenceRepository
      */
     public function setReference(string $name, object $reference)
     {
-        $class = $this->getRealClass(get_class($reference));
+        $class = $this->getRealClass($reference::class);
 
         $this->referencesByClass[$class][$name] = $reference;
 
@@ -136,7 +135,7 @@ class ReferenceRepository
      *
      * @return void
      */
-    public function setReferenceIdentity(string $name, $identity, ?string $class = null)
+    public function setReferenceIdentity(string $name, $identity, string|null $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -178,7 +177,7 @@ class ReferenceRepository
             ));
         }
 
-        $class = $this->getRealClass(get_class($object));
+        $class = $this->getRealClass($object::class);
         if (isset($this->referencesByClass[$class][$name])) {
             throw new BadMethodCallException(sprintf(
                 'Reference to "%s" for class "%s" already exists, use method setReference() in order to override it',
@@ -203,7 +202,7 @@ class ReferenceRepository
      *
      * @template T of object
      */
-    public function getReference(string $name, ?string $class = null)
+    public function getReference(string $name, string|null $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -232,7 +231,7 @@ class ReferenceRepository
             : ($this->identitiesByClass[$class][$name] ?? null);
 
         if ($class === null) { // For BC, to be removed in next major.
-            $class = $this->getRealClass(get_class($reference));
+            $class = $this->getRealClass($reference::class);
         }
 
         $meta = $this->manager->getClassMetadata($class);
@@ -254,7 +253,7 @@ class ReferenceRepository
      *
      * @return bool
      */
-    public function hasReference(string $name, ?string $class = null)
+    public function hasReference(string $name, string|null $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(
@@ -278,7 +277,7 @@ class ReferenceRepository
      */
     public function getReferenceNames(object $reference)
     {
-        $class = $this->getRealClass(get_class($reference));
+        $class = $this->getRealClass($reference::class);
         if (! isset($this->referencesByClass[$class])) {
             return [];
         }
@@ -293,7 +292,7 @@ class ReferenceRepository
      *
      * @return bool
      */
-    public function hasIdentity(string $name, ?string $class = null)
+    public function hasIdentity(string $name, string|null $class = null)
     {
         if ($class === null) {
             Deprecation::trigger(

--- a/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -88,7 +88,7 @@ class MongoDBPurgerTest extends BaseTestCase
         if (method_exists($documentManager, 'getClient')) {
             try {
                 $documentManager->getClient()->selectDatabase('admin')->command(['ping' => 1]);
-            } catch (ConnectionTimeoutException $driverException) {
+            } catch (ConnectionTimeoutException) {
                 $this->markTestSkipped('Unable to connect to MongoDB');
             }
 

--- a/tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
+++ b/tests/Common/DataFixtures/Purger/ORMPurgerExcludeTest.php
@@ -50,7 +50,7 @@ class ORMPurgerExcludeTest extends BaseTestCase
      *
      * @param string[] $list
      */
-    private function executeTestPurge(array $list, ?callable $filter): void
+    private function executeTestPurge(array $list, callable|null $filter): void
     {
         $em                 = $this->loadTestData();
         $excludedRepository = $em->getRepository(self::TEST_ENTITY_EXCLUDED);

--- a/tests/Common/DataFixtures/TestDocument/Role.php
+++ b/tests/Common/DataFixtures/TestDocument/Role.php
@@ -10,15 +10,15 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class Role
 {
     /** @ODM\Id */
-    private ?string $id = null;
+    private string|null $id = null;
 
     /**
      * @ODM\Field(type="string")
      * @ODM\Index
      */
-    private ?string $name = null;
+    private string|null $name = null;
 
-    public function getId(): ?string
+    public function getId(): string|null
     {
         return $this->id;
     }
@@ -28,7 +28,7 @@ class Role
         $this->name = $name;
     }
 
-    public function getName(): ?string
+    public function getName(): string|null
     {
         return $this->name;
     }

--- a/tests/Common/DataFixtures/TestEntity/Group.php
+++ b/tests/Common/DataFixtures/TestEntity/Group.php
@@ -16,7 +16,7 @@ class Group
      */
     #[ORM\Column]
     #[ORM\Id]
-    private ?int $id = null;
+    private int|null $id = null;
 
     /**
      * @ORM\Column(length=32)
@@ -24,14 +24,14 @@ class Group
      */
     #[ORM\Column(length: 32)]
     #[ORM\Id]
-    private ?string $code = null;
+    private string|null $code = null;
 
     public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }
@@ -41,7 +41,7 @@ class Group
         $this->code = $code;
     }
 
-    public function getCode(): ?string
+    public function getCode(): string|null
     {
         return $this->code;
     }

--- a/tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
+++ b/tests/Common/DataFixtures/TestEntity/GroupWithSchema.php
@@ -20,7 +20,7 @@ class GroupWithSchema
      */
     #[ORM\Column]
     #[ORM\Id]
-    private ?int $id = null;
+    private int|null $id = null;
 
     /**
      * @ORM\Column(length=32)
@@ -28,14 +28,14 @@ class GroupWithSchema
      */
     #[ORM\Column(length: 32)]
     #[ORM\Id]
-    private ?string $code = null;
+    private string|null $code = null;
 
     public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }
@@ -45,7 +45,7 @@ class GroupWithSchema
         $this->code = $code;
     }
 
-    public function getCode(): ?string
+    public function getCode(): string|null
     {
         return $this->code;
     }

--- a/tests/Common/DataFixtures/TestEntity/Link.php
+++ b/tests/Common/DataFixtures/TestEntity/Link.php
@@ -21,7 +21,7 @@ class Link
 
     /** @ORM\Column(length=150) */
     #[ORM\Column(length: 150)]
-    private ?string $url = null;
+    private string|null $url = null;
 
     public function __construct(Uuid $id)
     {
@@ -33,7 +33,7 @@ class Link
         return $this->id;
     }
 
-    public function getUrl(): ?string
+    public function getUrl(): string|null
     {
         return $this->url;
     }

--- a/tests/Common/DataFixtures/TestEntity/Quoted.php
+++ b/tests/Common/DataFixtures/TestEntity/Quoted.php
@@ -23,11 +23,11 @@ class Quoted
     #[ORM\Column]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private ?int $id = null;
+    private int|null $id = null;
 
     /** @ORM\Column(length=50, name="select") */
     #[ORM\Column(length: 50, name: '`SELECT`')]
-    private ?string $select = null;
+    private string|null $select = null;
 
     /**
      * @ORM\ManyToMany(targetEntity=Quoted::class)
@@ -40,34 +40,34 @@ class Quoted
     #[ORM\JoinTable(name: '`INSERT`')]
     #[ORM\JoinColumn(name: '`SELECT`', referencedColumnName: 'id')]
     #[ORM\InverseJoinColumn(name: '`UPDATE`', referencedColumnName: 'id')]
-    private ?Collection $selects = null;
+    private Collection|null $selects = null;
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }
 
-    public function setId(?int $id): void
+    public function setId(int|null $id): void
     {
         $this->id = $id;
     }
 
-    public function getSelect(): ?string
+    public function getSelect(): string|null
     {
         return $this->select;
     }
 
-    public function setSelect(?string $select): void
+    public function setSelect(string|null $select): void
     {
         $this->select = $select;
     }
 
-    public function getSelects(): ?Collection
+    public function getSelects(): Collection|null
     {
         return $this->selects;
     }
 
-    public function setSelects(?Collection $selects): void
+    public function setSelects(Collection|null $selects): void
     {
         $this->selects = $selects;
     }

--- a/tests/Common/DataFixtures/TestEntity/Role.php
+++ b/tests/Common/DataFixtures/TestEntity/Role.php
@@ -18,13 +18,13 @@ class Role
     #[ORM\Column]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private ?int $id = null;
+    private int|null $id = null;
 
     /** @ORM\Column(length=50) */
     #[ORM\Column(length: 50)]
-    private ?string $name = null;
+    private string|null $name = null;
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }
@@ -34,7 +34,7 @@ class Role
         $this->name = $name;
     }
 
-    public function getName(): ?string
+    public function getName(): string|null
     {
         return $this->name;
     }

--- a/tests/Common/DataFixtures/TestEntity/User.php
+++ b/tests/Common/DataFixtures/TestEntity/User.php
@@ -20,7 +20,7 @@ class User
      */
     #[ORM\Column]
     #[ORM\Id]
-    private ?int $id = null;
+    private int|null $id = null;
 
     /**
      * @ORM\Column(length=32)
@@ -28,19 +28,19 @@ class User
      */
     #[ORM\Column(length: 32)]
     #[ORM\Id]
-    private ?string $code = null;
+    private string|null $code = null;
 
     /** @ORM\Column(length=32) */
     #[ORM\Column(length: 32)]
-    private ?string $password = null;
+    private string|null $password = null;
 
     /** @ORM\Column(length=255) */
     #[ORM\Column(length: 255)]
-    private ?string $email = null;
+    private string|null $email = null;
 
     /** @ORM\ManyToOne(targetEntity=Role::class, cascade={"persist"}) */
     #[ORM\ManyToOne(cascade: ['persist'])]
-    private ?Role $role = null;
+    private Role|null $role = null;
 
     /**
      * @ORM\ManyToMany(targetEntity=User::class, inversedBy="authors")
@@ -76,7 +76,7 @@ class User
         $this->id = $id;
     }
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }
@@ -86,7 +86,7 @@ class User
         $this->code = $code;
     }
 
-    public function getCode(): ?string
+    public function getCode(): string|null
     {
         return $this->code;
     }
@@ -96,7 +96,7 @@ class User
         $this->password = md5($password);
     }
 
-    public function getPassword(): ?string
+    public function getPassword(): string|null
     {
         return $this->password;
     }
@@ -106,7 +106,7 @@ class User
         $this->email = $email;
     }
 
-    public function getEmail(): ?string
+    public function getEmail(): string|null
     {
         return $this->email;
     }
@@ -116,7 +116,7 @@ class User
         $this->role = $role;
     }
 
-    public function getRole(): ?Role
+    public function getRole(): Role|null
     {
         return $this->role;
     }

--- a/tests/Common/DataFixtures/TestEntity/UserWithSchema.php
+++ b/tests/Common/DataFixtures/TestEntity/UserWithSchema.php
@@ -24,7 +24,7 @@ class UserWithSchema
      */
     #[ORM\Column]
     #[ORM\Id]
-    private ?int $id = null;
+    private int|null $id = null;
 
     /**
      * @ORM\Column(length=32)
@@ -32,19 +32,19 @@ class UserWithSchema
      */
     #[ORM\Column(length: 32)]
     #[ORM\Id]
-    private ?string $code = null;
+    private string|null $code = null;
 
     /** @ORM\Column(length=32) */
     #[ORM\Column(length: 32)]
-    private ?string $password = null;
+    private string|null $password = null;
 
     /** @ORM\Column(length=255) */
     #[ORM\Column(length: 255)]
-    private ?string $email = null;
+    private string|null $email = null;
 
     /** @ORM\ManyToOne(targetEntity=Role::class, cascade={"persist"}) */
     #[ORM\ManyToOne(cascade: ['persist'])]
-    private ?Role $role = null;
+    private Role|null $role = null;
 
     /**
      * @ORM\ManyToMany(targetEntity=UserWithSchema::class, inversedBy="authors")
@@ -80,7 +80,7 @@ class UserWithSchema
         $this->id = $id;
     }
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }
@@ -90,7 +90,7 @@ class UserWithSchema
         $this->code = $code;
     }
 
-    public function getCode(): ?string
+    public function getCode(): string|null
     {
         return $this->code;
     }
@@ -100,7 +100,7 @@ class UserWithSchema
         $this->password = md5($password);
     }
 
-    public function getPassword(): ?string
+    public function getPassword(): string|null
     {
         return $this->password;
     }
@@ -110,7 +110,7 @@ class UserWithSchema
         $this->email = $email;
     }
 
-    public function getEmail(): ?string
+    public function getEmail(): string|null
     {
         return $this->email;
     }
@@ -120,7 +120,7 @@ class UserWithSchema
         $this->role = $role;
     }
 
-    public function getRole(): ?Role
+    public function getRole(): Role|null
     {
         return $this->role;
     }

--- a/tests/Common/DataFixtures/TestFixtures/RoleFixture.php
+++ b/tests/Common/DataFixtures/TestFixtures/RoleFixture.php
@@ -11,7 +11,7 @@ use Doctrine\Tests\Common\DataFixtures\TestEntity\Role;
 
 class RoleFixture implements SharedFixtureInterface
 {
-    private ?ReferenceRepository $referenceRepository = null;
+    private ReferenceRepository|null $referenceRepository = null;
 
     public function setReferenceRepository(ReferenceRepository $referenceRepository): void
     {

--- a/tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
+++ b/tests/Common/DataFixtures/TestPurgeEntity/ExcludedEntity.php
@@ -16,14 +16,14 @@ class ExcludedEntity
      */
     #[ORM\Column]
     #[ORM\Id]
-    private ?int $id = null;
+    private int|null $id = null;
 
     public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }

--- a/tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
+++ b/tests/Common/DataFixtures/TestPurgeEntity/IncludedEntity.php
@@ -16,14 +16,14 @@ class IncludedEntity
      */
     #[ORM\Column]
     #[ORM\Id]
-    private ?int $id = null;
+    private int|null $id = null;
 
     public function setId(int $id): void
     {
         $this->id = $id;
     }
 
-    public function getId(): ?int
+    public function getId(): int|null
     {
         return $this->id;
     }

--- a/tests/Common/DataFixtures/TestTypes/UuidType.php
+++ b/tests/Common/DataFixtures/TestTypes/UuidType.php
@@ -22,13 +22,13 @@ class UuidType extends Type
     }
 
     /** @param string|null $value */
-    public function convertToPHPValue($value, AbstractPlatform $platform): ?Uuid
+    public function convertToPHPValue($value, AbstractPlatform $platform): Uuid|null
     {
         return $value === null ? null : new Uuid($value);
     }
 
     /** @param Uuid|null $value */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): string|null
     {
         return $value === null ? null : (string) $value;
     }

--- a/tests/Common/DataFixtures/TestValueObjects/Uuid.php
+++ b/tests/Common/DataFixtures/TestValueObjects/Uuid.php
@@ -8,11 +8,8 @@ use JsonSerializable;
 
 class Uuid implements JsonSerializable
 {
-    private string $id;
-
-    public function __construct(string $id)
+    public function __construct(private string $id)
     {
-        $this->id = $id;
     }
 
     public function getId(): string

--- a/tests/Mock/ForwardCompatibleEntityManager.php
+++ b/tests/Mock/ForwardCompatibleEntityManager.php
@@ -11,8 +11,7 @@ use function method_exists;
 if (! method_exists(EntityManagerInterface::class, 'wrapInTransaction')) {
     interface ForwardCompatibleEntityManager extends EntityManagerInterface
     {
-        /** @return mixed */
-        public function wrapInTransaction(callable $func);
+        public function wrapInTransaction(callable $func): mixed;
     }
 } else {
     interface ForwardCompatibleEntityManager extends EntityManagerInterface

--- a/tests/Mock/Node.php
+++ b/tests/Mock/Node.php
@@ -9,12 +9,7 @@ namespace Doctrine\Tests\Mock;
  */
 class Node
 {
-    /** @var mixed */
-    public $value;
-
-    /** @param mixed $value */
-    public function __construct($value)
+    public function __construct(public mixed $value)
     {
-        $this->value = $value;
     }
 }


### PR DESCRIPTION
Dropping PHP 7 will allow us to simplify some code. It especially allows us to remove Doctrine Annotations from our fixtures. I'll do that in a follow-up PR.

All code changes in this PR resulted from running PHPCBF with the higher PHP language level.