### PR TITLE
Backport tests for strict return types

### DIFF
--- a/tests/Common/DataFixtures/Executor/ORMExecutorTest.php
+++ b/tests/Common/DataFixtures/Executor/ORMExecutorTest.php
@@ -52,8 +52,7 @@ class ORMExecutorTest extends BaseTestCase
         $em     = $this->getMockSqliteEntityManager();
         $purger = $this->getMockPurger();
         $purger->expects($this->once())
-            ->method('purge')
-            ->willReturn(null);
+            ->method('purge');
         $executor = new ORMExecutor($em, $purger);
         $fixture  = $this->getMockFixture();
         $fixture->expects($this->once())
@@ -103,8 +102,7 @@ class ORMExecutorTest extends BaseTestCase
         $em     = $this->getMockSqliteEntityManager();
         $purger = $this->getMockPurger();
         $purger->expects($this->once())
-            ->method('purge')
-            ->willReturn(null);
+            ->method('purge');
         $executor = new MultipleTransactionORMExecutor($em, $purger);
         $fixture  = $this->getMockFixture();
         $fixture->expects($this->once())

--- a/tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -199,6 +199,10 @@ class ReferenceRepositoryTest extends BaseTestCase
             ->with($role)
             ->willReturn($identitiesExpected);
 
+        $classMetadata->expects($this->once())
+            ->method('getName')
+            ->willReturn(Role::class);
+
         $em = $this->createMock(ForwardCompatibleEntityManager::class);
         $em->method('getUnitOfWork')
            ->willReturn($uow);


### PR DESCRIPTION
In order to add return types in #459, some tests needs to be updated.

I have a partial understanding of how `ReferenceRepository` works, with the metadata system. 

The [`setReference`](https://github.com/doctrine/data-fixtures/blob/a9784519696b08571054a266d1c64f1c06a40806/src/ReferenceRepository.php#L113C26-L113C26) method calls `getRealClass`, which required `$metadata->getName()`. Which is casted to  an empty string when the mock isn't defined for this method call.