### PR TITLE
Fix PHPCR tests for PHPUnit 10

### DIFF
--- a/tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
+++ b/tests/Common/DataFixtures/Executor/PHPCRExecutorTest.php
@@ -9,6 +9,7 @@ use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Tests\Common\DataFixtures\BaseTestCase;
+use Doctrine\Tests\Mock\PHPCRDocumentManager;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use Throwable;
@@ -125,20 +126,15 @@ class PHPCRExecutorTest extends BaseTestCase
         return $this->createMock(PHPCRPurger::class);
     }
 
-    /** @return DocumentManager&MockObject */
-    private function getDocumentManager(): DocumentManager
+    /** @return PHPCRDocumentManager&MockObject */
+    private function getDocumentManager(): PHPCRDocumentManager
     {
         if (! class_exists(DocumentManager::class)) {
             $this->markTestSkipped('Missing doctrine/phpcr-odm');
         }
 
         return $this
-            ->getMockBuilder(DocumentManager::class)
-            ->addMethods([
-                'transactional',
-                'flush',
-                'clear',
-            ])
+            ->getMockBuilder(PHPCRDocumentManager::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Mock/PHPCRDocumentManager.php
+++ b/tests/Mock/PHPCRDocumentManager.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Mock;
+
+use Closure;
+use Doctrine\ODM\PHPCR\DocumentManager;
+
+abstract class PHPCRDocumentManager extends DocumentManager
+{
+    abstract public function transactional(Closure $func): void;
+}


### PR DESCRIPTION
`MockBuilder::addMethods()` is deprecated in PHPUnit 10.1 https://github.com/sebastianbergmann/phpunit/issues/5320

To run the tests with PHPCR, I have to add this to `composer.json`:

```json
        "doctrine/phpcr-odm": "^1.8",
        "jackalope/jackalope-fs": "*",
```

And run `COMPOSER_ROOT_VERSION=1.99 composer update`