### PR TITLE
Fix order of sorting for cyclic dependencies

### DIFF
--- a/src/Sorter/TopologicalSorter.php
+++ b/src/Sorter/TopologicalSorter.php
@@ -186,7 +186,7 @@ EXCEPTION
         $this->sortedNodeList[] = $definition->value;
     }
 
-    public function getDefinition(string $dependency, Vertex $definition): Vertex
+    private function getDefinition(string $dependency, Vertex $definition): Vertex
     {
         if (! isset($this->nodeList[$dependency])) {
             throw new RuntimeException(sprintf(

--- a/src/Sorter/TopologicalSorter.php
+++ b/src/Sorter/TopologicalSorter.php
@@ -8,12 +8,9 @@ use Doctrine\Common\DataFixtures\Exception\CircularReferenceException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use RuntimeException;
 
-use function array_unshift;
 use function count;
-use function get_class;
 use function sprintf;
 use function uasort;
-use function usort;
 
 /**
  * TopologicalSorter is an ordering algorithm for directed graphs (DG) and/or
@@ -34,13 +31,6 @@ class TopologicalSorter
      * @var Vertex[]
      */
     private array $nodeList = [];
-
-    /**
-     * Volatile variable holding cyclic nodes during sorting process.
-     *
-     * @var Vertex[]
-     */
-    private array $cyclicNodeList = [];
 
     /**
      * Volatile variable holding calculated nodes during sorting process.

--- a/tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
+++ b/tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
@@ -83,17 +83,53 @@ class TopologicalSorterTest extends BaseTestCase
         $node1 = new ClassMetadata('1');
         $node2 = new ClassMetadata('2');
         $node3 = new ClassMetadata('3');
+        $node4 = new ClassMetadata('4');
+        $node5 = new ClassMetadata('5');
 
         $sorter->addNode('1', $node1);
         $sorter->addNode('2', $node2);
         $sorter->addNode('3', $node3);
+        $sorter->addNode('4', $node4);
+        $sorter->addNode('5', $node5);
 
         $sorter->addDependency('1', '2');
+        $sorter->addDependency('1', '4');
         $sorter->addDependency('2', '3');
-        $sorter->addDependency('3', '1');
+        $sorter->addDependency('5', '1');
+        $sorter->addDependency('3', '4');
 
         $sortedList  = $sorter->sort();
-        $correctList = [$node3, $node2, $node1];
+        $correctList = [$node4, $node3, $node2, $node1, $node5];
+
+        self::assertSame($correctList, $sortedList);
+
+        $sorter->sort();
+    }
+
+    public function testSortCyclicDependencyWhenNodesAreAddedInAnotherOrder(): void
+    {
+        $sorter = new TopologicalSorter();
+
+        $node1 = new ClassMetadata('1');
+        $node2 = new ClassMetadata('2');
+        $node3 = new ClassMetadata('3');
+        $node4 = new ClassMetadata('4');
+        $node5 = new ClassMetadata('5');
+
+        $sorter->addNode('5', $node5);
+        $sorter->addNode('4', $node4);
+        $sorter->addNode('3', $node3);
+        $sorter->addNode('2', $node2);
+        $sorter->addNode('1', $node1);
+
+        $sorter->addDependency('1', '2');
+        $sorter->addDependency('1', '4');
+        $sorter->addDependency('2', '3');
+        $sorter->addDependency('5', '1');
+        $sorter->addDependency('3', '4');
+
+        $sortedList  = $sorter->sort();
+        $correctList = [$node4, $node3, $node2, $node1, $node5];
 
         self::assertSame($correctList, $sortedList);
 

--- a/tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
+++ b/tests/Common/DataFixtures/Sorter/TopologicalSorterTest.php
@@ -11,6 +11,7 @@ use Doctrine\Tests\Common\DataFixtures\BaseTestCase;
 use RuntimeException;
 
 use function array_map;
+use function array_search;
 use function array_splice;
 use function array_unshift;
 use function count;
@@ -137,13 +138,21 @@ class TopologicalSorterTest extends BaseTestCase
         $sorter->addDependency('4', '2');
         $sorter->addDependency('2', '5');
 
-        $sortedList = self::nodeNames($sorter->sort());
+        $sortedList    = self::nodeNames($sorter->sort());
+        $node1Position = array_search('1', $sortedList);
+        $node2Position = array_search('2', $sortedList);
+        $node3Position = array_search('3', $sortedList);
+        $node4Position = array_search('4', $sortedList);
+        $node5Position = array_search('5', $sortedList);
 
-        self::assertCount(5, $sortedList);
-        self::assertSame('5', $sortedList[0]);
-        self::assertSame('1', $sortedList[4]);
+        self::assertTrue($node5Position < $node2Position, '5 should come before 2');
+        self::assertTrue($node5Position < $node3Position, '5 should come before 3');
+        self::assertTrue($node5Position < $node4Position, '5 should come before 4');
+        self::assertTrue($node1Position > $node5Position, '1 should come after 2');
+        self::assertTrue($node1Position > $node3Position, '1 should come after 3');
+        self::assertTrue($node1Position > $node4Position, '1 should come after 4');
 
-        // these a cyclic and sort order is based on the order of the nodeList, and is a best effort
+        // these a cyclic and sort order is based on the order of the nodes
         self::assertContains('2', $sortedList);
         self::assertContains('3', $sortedList);
         self::assertContains('4', $sortedList);


### PR DESCRIPTION
Fix order of sorting for cyclic dependencies where multiple dependencies are assumed to always
go after the cyclic one

In the test case:
Lets assume none of the FK allow cascading deletes

Removing Node 1 would be blocked by Node 2
Removing Node 2 would be blocked by Node 3 and Node 5
Removing Node 3 would be blocked by Node 4 -> cyclic through 4 -> 2 -> 3
Removing Node 4 would be blocked by Node 2 -> cyclic through 2 -> 3 -> 4
Removing node 5 is not blocked by any nodes


So We need to first remove Node 5, which is not blocked by any node
And Node 1 is not part is a cyclic dependency itself, but Node 2 references it, so Node 1 must always come somewhere after Node 2, which is part of a cyclic dep so Node 1 should then come after the other nodes

The rest of the nodes [2, 3, 4] are locked in cyclic dep. so we cannot really resolve them in a favourable way, unless we
try to identify which dependencies are blocking and which ones are not (deleting/nulling FKs or not), only listing the blocking dependencies should also resolve the issue, making the chance of success higher, this is however done by the Purger
