### PR TITLE
Update getReference phpdoc

### DIFF
--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -198,8 +198,6 @@ class ReferenceRepository
     /**
      * Loads an object using stored reference named by $name
      *
-     * @template T of object
-     *
      * @param string $name
      * @psalm-param class-string<T>|null $class
      *
@@ -207,6 +205,8 @@ class ReferenceRepository
      * @psalm-return ($class is null ? object : T)
      *
      * @throws OutOfBoundsException - if repository does not exist.
+     *
+     * @template T of object
      */
     public function getReference($name, ?string $class = null)
     {

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -196,18 +196,17 @@ class ReferenceRepository
     }
 
     /**
-     * Loads an object using stored reference
-     * named by $name
+     * Loads an object using stored reference named by $name
+     *
+     * @template T of object
      *
      * @param string $name
      * @psalm-param class-string<T>|null $class
      *
-     * @return object
+     * @return T|object
      * @psalm-return ($class is null ? object : T)
      *
      * @throws OutOfBoundsException - if repository does not exist.
-     *
-     * @template T of object
      */
     public function getReference($name, ?string $class = null)
     {


### PR DESCRIPTION
Fix of the PHPDoc for the getReference method to allow code editor such as PhpStorm (and probably others) to correctly understand that the return of the method is an instance of $class and not any object.

Without this fix, PhpStorm cannot autocomplete the methods of the object retrieved by the getReference method, and with this proposal, it works.