### PR TITLE
Ensure the codebase is totally typed

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,9 +10,9 @@ awareness about deprecated code.
 
 You need PHP 8.1 or newer to use this library.
 
-## BC BREAK: Add return types to all the methods
+## BC BREAK: Add native types declarations to all the methods
 
-All return types defined in phpdoc `@return` are now defined in the method signature,
+All types defined in phpdoc annotations are now defined natively,
 they must be added to your code if you extend the classes or implement the interfaces.
 
 ## Loggers have to implement the PSR-3 contracts

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,16 +44,10 @@
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
-        <!-- Adding parameter types is a BC break in most cases because of strict types. -->
-        <exclude-pattern>src/*</exclude-pattern>
-
+        <!-- ORM 3 compatibility -->
+        <exclude-pattern>src/Purger/ORMPurger.php</exclude-pattern>
         <!-- Don't add parameter types to overridden methods -->
         <exclude-pattern>tests/Common/DataFixtures/TestTypes/UuidType.php</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
-        <!-- Adding property types is a BC break in most cases. -->
-        <exclude-pattern>src/*</exclude-pattern>
     </rule>
 
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">

--- a/src/AbstractFixture.php
+++ b/src/AbstractFixture.php
@@ -17,10 +17,8 @@ abstract class AbstractFixture implements SharedFixtureInterface
 {
     /**
      * Fixture reference repository
-     *
-     * @var ReferenceRepository|null
      */
-    protected $referenceRepository;
+    protected ReferenceRepository|null $referenceRepository = null;
 
     public function setReferenceRepository(ReferenceRepository $referenceRepository): void
     {

--- a/src/Executor/AbstractExecutor.php
+++ b/src/Executor/AbstractExecutor.php
@@ -28,17 +28,13 @@ abstract class AbstractExecutor implements LoggerAwareInterface
 
     /**
      * Purger instance for purging database before loading data fixtures
-     *
-     * @var PurgerInterface|null
      */
-    protected $purger;
+    protected PurgerInterface|null $purger = null;
 
     /**
      * Fixture reference repository
-     *
-     * @var ReferenceRepository
      */
-    protected $referenceRepository;
+    protected ReferenceRepository $referenceRepository;
 
     public function __construct(ObjectManager $manager)
     {

--- a/src/Purger/ORMPurger.php
+++ b/src/Purger/ORMPurger.php
@@ -29,10 +29,8 @@ class ORMPurger implements PurgerInterface, ORMPurgerInterface
 
     /**
      * If the purge should be done through DELETE or TRUNCATE statements
-     *
-     * @var int
      */
-    private $purgeMode = self::PURGE_MODE_DELETE;
+    private int $purgeMode = self::PURGE_MODE_DELETE;
 
     /**
      * Table/view names to be excluded from purge

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -102,10 +102,9 @@ class ReferenceRepository
     /**
      * Store the identifier of a reference
      *
-     * @param mixed        $identity
      * @param class-string $class
      */
-    public function setReferenceIdentity(string $name, $identity, string $class): void
+    public function setReferenceIdentity(string $name, mixed $identity, string $class): void
     {
         $this->identitiesByClass[$class][$name] = $identity;
     }


### PR DESCRIPTION
This implies adding an exception for one of the type declarations would require ORM 3.