### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,16 +5,28 @@
     "docsSlug": "doctrine-data-fixtures",
     "versions": [
         {
-            "name": "2.0",
-            "branchName": "2.0.x",
+            "name": "3.0",
+            "branchName": "3.0.x",
             "slug": "latest",
             "upcoming": true
+        },
+        {
+            "name": "2.1",
+            "branchName": "2.1.x",
+            "slug": "2.1",
+            "upcoming": true
+        },
+        {
+            "name": "2.0",
+            "branchName": "2.0.x",
+            "slug": "2.0",
+            "current": true
         },
         {
             "name": "1.8",
             "branchName": "1.8.x",
             "slug": "1.8",
-            "current": true
+            "maintained": true
         },
         {
             "name": "1.7",


### PR DESCRIPTION
- 2.0.x is the new current branch
- 1.8.x is still maintained
- 2.1.x and 3.0.x exist