### PR TITLE
Use 1.8.x as the target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
+    target-branch: "1.8.x"


### PR DESCRIPTION
We just released 2.0.0, so 1.8.x is going to stay maintained for a while. Because of that, the default branch and the lowest branch differ, and we should send dependabot updates to the lowest branch.