### PR TITLE
Relax type of identifiers

### DIFF
--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -73,7 +73,7 @@ class ReferenceRepository
      * @param object $reference Reference object
      * @param object $uow       Unit of work
      *
-     * @return array
+     * @return mixed
      */
     protected function getIdentifier(object $reference, object $uow)
     {
@@ -324,7 +324,7 @@ class ReferenceRepository
     /**
      * Get all stored identities
      *
-     * @phpstan-return array<class-string, array<string, object>>
+     * @phpstan-return array<class-string, array<string, mixed>>
      */
     public function getIdentitiesByClass(): array
     {


### PR DESCRIPTION
ORM and ODM and other things having an implementation of ReferenceRepository do not necessarily agree on what an identifier should be.
data-fixtures should not really care either so long as the identifier can be used with serialize().
Let us relax the type of identifers to mixed.