### PR TITLE
Fix error when use numeric for reference name

### DIFF
--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -12,6 +12,7 @@ use OutOfBoundsException;
 
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function sprintf;
 
 /**

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -192,7 +192,7 @@ class ReferenceRepository
             return [];
         }
 
-        return array_keys($this->referencesByClass[$class], $reference, true);
+        return array_map('strval', array_keys($this->referencesByClass[$class], $reference, true));
     }
 
     /**

--- a/tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -245,7 +245,7 @@ class ReferenceRepositoryTest extends BaseTestCase
 
     public function testGivenAReferenceWithNameWithIntegerValueWhenGetReferenceNamesOfEntitiesThenReturnNamesInStringType(): void
     {
-        $em = $this->getMockSqliteEntityManager();
+        $em                  = $this->getMockSqliteEntityManager();
         $referenceRepository = new ReferenceRepository($em);
 
         $schemaTool = new SchemaTool($em);
@@ -257,7 +257,7 @@ class ReferenceRepositoryTest extends BaseTestCase
         $em->persist($role);
         $em->flush();
 
-        $name = (string)$role->getId();
+        $name = (string) $role->getId();
         $referenceRepository->setReference($name, $role);
         $names = $referenceRepository->getReferenceNames($role);
         $this->assertCount(1, $names);

--- a/tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -242,4 +242,25 @@ class ReferenceRepositoryTest extends BaseTestCase
 
         $this->assertEquals($identitiesExpected, $identities['entity']);
     }
+
+    public function testGivenAReferenceWithNameWithIntegerValueWhenGetReferenceNamesOfEntitiesThenReturnNamesInStringType(): void
+    {
+        $em = $this->getMockSqliteEntityManager();
+        $referenceRepository = new ReferenceRepository($em);
+
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->dropSchema([]);
+        $schemaTool->createSchema([$em->getClassMetadata(Role::class)]);
+
+        $role = new Role();
+        $role->setName('role_name');
+        $em->persist($role);
+        $em->flush();
+
+        $name = (string)$role->getId();
+        $referenceRepository->setReference($name, $role);
+        $names = $referenceRepository->getReferenceNames($role);
+        $this->assertCount(1, $names);
+        $this->assertSame('1', $names[0]);
+    }
 }


### PR DESCRIPTION
Fix #512 

The method `ReferenceRepository::setReferenceIdentity(string $name, mixed $identity, string $class): void`  typed the parameter `$name` with `string` and numeric reference names is cast to integers when are recovered from `ReferenceRepository::getReferenceNames($object)` method in previous lines, so when pass the value of numeric name in integer with a parameter typed with string then fails.

So I propose a fix to cast names to string in `ReferenceRepository::getReferenceNames($object)` when are returned
