### PR TITLE
Fix error when use numeric for reference name

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -261,23 +261,11 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$className of method Doctrine\\Persistence\\ObjectManager\:\:getClassMetadata\(\) expects class\-string\<object\>, string given\.$#'
 			identifier: argument.type
-			count: 2
-			path: src/ReferenceRepository.php
-
-		-
-			message: '#^Property Doctrine\\Common\\DataFixtures\\ReferenceRepository\:\:\$identitiesByClass \(array\<class\-string, array\<string, mixed\>\>\) does not accept array\<string, array\<string, mixed\>\>\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/ReferenceRepository.php
-
-		-
-			message: '#^Property Doctrine\\Common\\DataFixtures\\ReferenceRepository\:\:\$referencesByClass \(array\<class\-string, array\<string, object\>\>\) does not accept array\<string, array\<string, mixed\>\>\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: src/ReferenceRepository.php
 
 		-
-			message: '#^Property Doctrine\\Common\\DataFixtures\\ReferenceRepository\:\:\$referencesByClass \(array\<class\-string, array\<string, object\>\>\) does not accept array\<string, array\<string, object\>\>\.$#'
+			message: '#^Property Doctrine\\Common\\DataFixtures\\ReferenceRepository\:\:\$identitiesByClass \(array\<class\-string, array\<string, mixed\>\>\) does not accept array\<string, array\<string, mixed\>\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/ReferenceRepository.php
@@ -285,7 +273,7 @@ parameters:
 		-
 			message: '#^Unable to resolve the template type T in call to method Doctrine\\Persistence\\ObjectManager\:\:getClassMetadata\(\)$#'
 			identifier: argument.templateType
-			count: 2
+			count: 1
 			path: src/ReferenceRepository.php
 
 		-

--- a/src/ReferenceRepository.php
+++ b/src/ReferenceRepository.php
@@ -13,6 +13,7 @@ use OutOfBoundsException;
 
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function get_class;
 use function sprintf;
 
@@ -35,7 +36,7 @@ class ReferenceRepository
      * List of named references to the fixture objects
      * gathered during fixure loading
      *
-     * @phpstan-var array<class-string, array<string, object>>
+     * @phpstan-var array<class-string, array<string|int, object>>
      */
     private array $referencesByClass = [];
 
@@ -283,7 +284,7 @@ class ReferenceRepository
             return [];
         }
 
-        return array_keys($this->referencesByClass[$class], $reference, true);
+        return array_map('strval', array_keys($this->referencesByClass[$class], $reference, true));
     }
 
     /**
@@ -346,7 +347,7 @@ class ReferenceRepository
     /**
      * Get all stored references
      *
-     * @phpstan-return array<class-string, array<string, object>>
+     * @phpstan-return array<class-string, array<string|int, object>>
      */
     public function getReferencesByClass(): array
     {
@@ -368,7 +369,7 @@ class ReferenceRepository
      *
      * @param string $className Class name of reference object
      *
-     * @return string
+     * @return class-string
      */
     protected function getRealClass(string $className)
     {

--- a/tests/Common/DataFixtures/ReferenceRepositoryTest.php
+++ b/tests/Common/DataFixtures/ReferenceRepositoryTest.php
@@ -268,4 +268,25 @@ class ReferenceRepositoryTest extends BaseTestCase
 
         $this->assertEquals($identitiesExpected, $identities['entity']);
     }
+
+    public function testGivenAReferenceWithNameWithIntegerValueWhenGetReferenceNamesOfEntitiesThenReturnNamesInStringType(): void
+    {
+        $em                  = $this->getMockSqliteEntityManager();
+        $referenceRepository = new ReferenceRepository($em);
+
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->dropSchema([]);
+        $schemaTool->createSchema([$em->getClassMetadata(Role::class)]);
+
+        $role = new Role();
+        $role->setName('role_name');
+        $em->persist($role);
+        $em->flush();
+
+        $name = (string) $role->getId();
+        $referenceRepository->setReference($name, $role);
+        $names = $referenceRepository->getReferenceNames($role);
+        $this->assertCount(1, $names);
+        $this->assertSame('1', $names[0]);
+    }
 }


### PR DESCRIPTION
Fix https://github.com/doctrine/data-fixtures/issues/512

The method ReferenceRepository::setReferenceIdentity(string $name, mixed $identity, string $class): void typed the parameter $name with string and numeric reference names is cast to integers when are recovered from ReferenceRepository::getReferenceNames($object) method in previous lines, so when pass the value of numeric name in integer with a parameter typed with string then fails.

So I propose a fix to cast names to string in ReferenceRepository::getReferenceNames($object) when are returned