### PR TITLE
Allow doctrine persistence v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/persistence": "^3.1",
+        "doctrine/persistence": "^3.1 || ^4.0",
         "psr/log": "^1.1 || ^2 || ^3"
     },
     "conflict": {


### PR DESCRIPTION
Since doctrine orm v3.3 package support both version of persistence then make sense allow it here.