### PR TITLE
Pin development tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "11:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "Dependencies"
+    versioning-strategy: "increase-if-necessary"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
         "doctrine/orm": "^2.14 || ^3",
         "fig/log-test": "^1",
-        "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.6.13 || ^10.4.2",
+        "phpstan/phpstan": "1.12.21",
+        "phpunit/phpunit": "^9.6.13 || 10.5.45",
         "psr/log": "^1.1 || ^2 || ^3",
         "symfony/cache": "^5.4 || ^6.3 || ^7",
         "symfony/var-exporter": "^5.4 || ^6.3 || ^7"


### PR DESCRIPTION
The goal of the job introduced in #453 is to catch issues introduced by Doctrine packages. Let us avoid suprises caused by development tools by pinning them, and having dependabot bump the version constraint as suggested in https://github.com/doctrine/data-fixtures/pull/475#issuecomment-2094819310