### PR TITLE
Target 1.8.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     labels:
       - "Dependencies"
     versioning-strategy: "increase-if-necessary"
+    target-branch: "1.8.x"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
1.x is still maintained, and we do not want to make merge ups difficult, so let us avoid differences in development tools versions.