### PR TITLE
Add purge mode to MongoDB Purger

### DIFF
--- a/src/Purger/MongoDBPurgeMode.php
+++ b/src/Purger/MongoDBPurgeMode.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\DataFixtures\Purger;
+
+enum MongoDBPurgeMode: string
+{
+    /**
+     * Purge the collections using deleteMany(). Don't create them.
+     */
+    case Delete = 'delete';
+
+    /**
+     * Drop the collections when purging, then recreate them.
+     */
+    case Drop = 'drop';
+}

--- a/src/Purger/MongoDBPurger.php
+++ b/src/Purger/MongoDBPurger.php
@@ -5,25 +5,15 @@ declare(strict_types=1);
 namespace Doctrine\Common\DataFixtures\Purger;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
-use LogicException;
+
+use function method_exists;
 
 /**
  * Class responsible for purging databases of data before reloading data fixtures.
  */
 final class MongoDBPurger implements MongoDBPurgerInterface
 {
-    /**
-     * Purge the collections using deleteMany(). Don't create them.
-     */
-    public const PURGE_MODE_DELETE = 1;
-
-    /**
-     * Drop the collections when purging, then recreate them.
-     */
-    public const PURGE_MODE_DROP = 2;
-
-    /** @var self::PURGE_MODE_* $mode */
-    private int $purgeMode = self::PURGE_MODE_DELETE;
+    private MongoDBPurgeMode $purgeMode = MongoDBPurgeMode::Drop;
 
     /**
      * Construct new purger instance.
@@ -35,21 +25,14 @@ final class MongoDBPurger implements MongoDBPurgerInterface
     }
 
     /**
-     * If the purge should be done through collection drop() or deleteMany() statements
-     *
-     * @param self::PURGE_MODE_* $mode
+     * If the purge should be done through collection drop() or deleteMany()
      */
-    public function setPurgeMode(int $mode): void
+    public function setPurgeMode(MongoDBPurgeMode $mode): void
     {
         $this->purgeMode = $mode;
     }
 
-    /**
-     * Get the purge mode
-     *
-     * @return self::PURGE_MODE_*
-     */
-    public function getPurgeMode(): int
+    public function getPurgeMode(): MongoDBPurgeMode
     {
         return $this->purgeMode;
     }
@@ -73,9 +56,8 @@ final class MongoDBPurger implements MongoDBPurgerInterface
     public function purge(): void
     {
         match ($this->purgeMode) {
-            self::PURGE_MODE_DELETE => $this->purgeWithDelete(),
-            self::PURGE_MODE_DROP => $this->purgeWithDrop(),
-            default => throw new LogicException('Invalid purge mode specified.'),
+            MongoDBPurgeMode::Delete => $this->purgeWithDelete(),
+            MongoDBPurgeMode::Drop => $this->purgeWithDrop(),
         };
     }
 
@@ -105,8 +87,9 @@ final class MongoDBPurger implements MongoDBPurgerInterface
         $schemaManager = $this->dm->getSchemaManager();
         $schemaManager->createCollections();
         $schemaManager->ensureIndexes();
-        if (method_exists($schemaManager, 'createSearchIndexes')) {
-            $schemaManager->createSearchIndexes();
-        }
+
+        // Requires doctrine/mongodb-odm 2.8
+        // @phpstan-ignore function.alreadyNarrowedType
+        method_exists($schemaManager, 'createSearchIndexes') && $schemaManager->createSearchIndexes();
     }
 }

--- a/src/Purger/MongoDBPurger.php
+++ b/src/Purger/MongoDBPurger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Common\DataFixtures\Purger;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
+use LogicException;
 
 /**
  * Class responsible for purging databases of data before reloading data fixtures.
@@ -12,12 +13,45 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 final class MongoDBPurger implements MongoDBPurgerInterface
 {
     /**
+     * Purge the collections using deleteMany(). Don't create them.
+     */
+    public const PURGE_MODE_DELETE = 1;
+
+    /**
+     * Drop the collections when purging, then recreate them.
+     */
+    public const PURGE_MODE_DROP = 2;
+
+    /** @var self::PURGE_MODE_* $mode */
+    private int $purgeMode = self::PURGE_MODE_DELETE;
+
+    /**
      * Construct new purger instance.
      *
      * @param DocumentManager|null $dm DocumentManager instance used for persistence.
      */
     public function __construct(private DocumentManager|null $dm = null)
     {
+    }
+
+    /**
+     * If the purge should be done through collection drop() or deleteMany() statements
+     *
+     * @param self::PURGE_MODE_* $mode
+     */
+    public function setPurgeMode(int $mode): void
+    {
+        $this->purgeMode = $mode;
+    }
+
+    /**
+     * Get the purge mode
+     *
+     * @return self::PURGE_MODE_*
+     */
+    public function getPurgeMode(): int
+    {
+        return $this->purgeMode;
     }
 
     /**
@@ -38,8 +72,29 @@ final class MongoDBPurger implements MongoDBPurgerInterface
 
     public function purge(): void
     {
-        $metadatas = $this->dm->getMetadataFactory()->getAllMetadata();
-        foreach ($metadatas as $metadata) {
+        match ($this->purgeMode) {
+            self::PURGE_MODE_DELETE => $this->purgeWithDelete(),
+            self::PURGE_MODE_DROP => $this->purgeWithDrop(),
+            default => throw new LogicException('Invalid purge mode specified.'),
+        };
+    }
+
+    private function purgeWithDelete(): void
+    {
+        $allMetadata = $this->dm->getMetadataFactory()->getAllMetadata();
+        foreach ($allMetadata as $metadata) {
+            if ($metadata->isMappedSuperclass) {
+                continue;
+            }
+
+            $this->dm->getDocumentCollection($metadata->name)->deleteMany([]);
+        }
+    }
+
+    private function purgeWithDrop(): void
+    {
+        $allMetadata = $this->dm->getMetadataFactory()->getAllMetadata();
+        foreach ($allMetadata as $metadata) {
             if ($metadata->isMappedSuperclass) {
                 continue;
             }
@@ -47,6 +102,11 @@ final class MongoDBPurger implements MongoDBPurgerInterface
             $this->dm->getDocumentCollection($metadata->name)->drop();
         }
 
-        $this->dm->getSchemaManager()->ensureIndexes();
+        $schemaManager = $this->dm->getSchemaManager();
+        $schemaManager->createCollections();
+        $schemaManager->ensureIndexes();
+        if (method_exists($schemaManager, 'createSearchIndexes')) {
+            $schemaManager->createSearchIndexes();
+        }
     }
 }

--- a/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -49,6 +49,37 @@ class MongoDBPurgerTest extends BaseTestCase
         return new MongoDBPurger($this->getDocumentManager());
     }
 
+    public function testPurgeWithDelete(): void
+    {
+        $purger = $this->getPurger();
+        $dm     = $purger->getObjectManager();
+        $purger->setPurgeMode(MongoDBPurger::PURGE_MODE_DELETE);
+
+        $collection = $dm->getDocumentCollection(self::TEST_DOCUMENT_ROLE);
+        $collection->drop();
+
+        $this->assertIndexCount(0, $collection);
+
+        $purger->purge();
+
+        // Collection isn't created yet, so no indices should be present
+        $this->assertIndexCount(0, $collection);
+
+        $role = new Role();
+        $role->setName('role');
+        $dm->persist($role);
+        $dm->flush();
+
+        // Only the _id_ index should be present after the document is created
+        $this->assertIndexCount(1, $collection);
+
+        $purger->purge();
+
+        // After purging, the collection should still exist, but the document should be deleted
+        $this->assertIndexCount(1, $collection);
+        $this->assertSame(0, $collection->countDocuments());
+    }
+
     public function testPurgeKeepsIndices(): void
     {
         $purger = $this->getPurger();

--- a/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\DataFixtures\Purger;
 
+use Doctrine\Common\DataFixtures\Purger\MongoDBPurgeMode;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -53,7 +54,7 @@ class MongoDBPurgerTest extends BaseTestCase
     {
         $purger = $this->getPurger();
         $dm     = $purger->getObjectManager();
-        $purger->setPurgeMode(MongoDBPurger::PURGE_MODE_DELETE);
+        $purger->setPurgeMode(MongoDBPurgeMode::Delete);
 
         $collection = $dm->getDocumentCollection(self::TEST_DOCUMENT_ROLE);
         $collection->drop();

--- a/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -56,6 +56,8 @@ class MongoDBPurgerTest extends BaseTestCase
         $dm     = $purger->getObjectManager();
         $purger->setPurgeMode(MongoDBPurgeMode::Delete);
 
+        self::assertSame(MongoDBPurgeMode::Delete, $purger->getPurgeMode());
+
         $collection = $dm->getDocumentCollection(self::TEST_DOCUMENT_ROLE);
         $collection->drop();
 

--- a/tests/Common/DataFixtures/TestDocument/AbstractRole.php
+++ b/tests/Common/DataFixtures/TestDocument/AbstractRole.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\DataFixtures\TestDocument;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\MappedSuperclass]
+class AbstractRole
+{
+    #[ODM\Id]
+    public string|null $id = null;
+}


### PR DESCRIPTION
Currently, the MongoDB purger drops the collection in order to purge it. Then it uses the SchemaManager to recreate its indexes.

But this approach isn't complete as other elements need to be created:
- The search indexes (requires ODM v2.8+ with https://github.com/doctrine/mongodb-odm/pull/2630)
- The auto encryption metadata (coming in https://github.com/doctrine/mongodb-odm/pull/2779)

Adding a new strategy that uses `deleteMany` to keep the collection instead of dropping and recreating everything. This is very important for Auto Encryption as the encryption keys are generated randomly each time an encrypted collection is created.

 For the ORM, the purge mode in set by a command option [`purge-with-truncate`](https://github.com/doctrine/DoctrineFixturesBundle/blob/901d0e84d05f49c94765e95782b277ca14393133/src/Command/LoadDataFixturesDoctrineCommand.php#L118). We have to add such option in the [`doctrine:mongodb:fixtures:load` command](https://github.com/doctrine/DoctrineMongoDBBundle/blob/5.4.x/src/Command/LoadDataFixturesDoctrineODMCommand.php)

[PHPORM-364](https://jira.mongodb.org/browse/PHPORM-364)