### PR TITLE
Add DryRunORMExecutor class for dry-run support

### DIFF
--- a/docs/en/how-to/loading-fixtures.rst
+++ b/docs/en/how-to/loading-fixtures.rst
@@ -124,3 +124,16 @@ To do so, you can use ``MultipleTransactionORMExecutor``.
 
     <?php
     $executor = new MultipleTransactionORMExecutor($entityManager, new ORMPurger());
+
+If you want to simulate the execution of fixtures without applying 
+any changes to the database, you can use ``DryRunORMExecutor``.
+This executor will execute your fixtures, but instead of persisting and
+committing changes, it wraps the entire process in a transaction and
+rolls it back at the end. 
+This allows you to inspect the behavior of your fixtures safely, without 
+modifying the database:
+
+.. code-block:: php
+
+    <?php
+    $executor = new DryRunORMExecutor($entityManager, new ORMPurger());

--- a/src/Executor/DryRunORMExecutor.php
+++ b/src/Executor/DryRunORMExecutor.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\DataFixtures\Executor;
+
+/**
+ * This executor allows to execute (and indirectly, print) SQL statements without
+ * actually committing them to the database
+ */
+final class DryRunORMExecutor extends AbstractExecutor
+{
+    use ORMExecutorCommon;
+
+    /** @inheritDoc */
+    public function execute(array $fixtures, bool $append = false): void
+    {
+        $executor = $this;
+        $this->em->beginTransaction();
+        try {
+            if ($append === false) {
+                $executor->purge();
+            }
+
+            foreach ($fixtures as $fixture) {
+                $executor->load($this->em, $fixture);
+            }
+
+            $this->em->flush();
+        } finally {
+            $this->em->rollBack();
+            $this->em->close();
+        }
+    }
+}

--- a/tests/Common/DataFixtures/Executor/DryRunORMExecutorTest.php
+++ b/tests/Common/DataFixtures/Executor/DryRunORMExecutorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\DataFixtures\Executor;
+
+use Doctrine\Common\DataFixtures\Executor\DryRunORMExecutor;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\Purger\ORMPurgerInterface;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Tests\Common\DataFixtures\BaseTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+
+class DryRunORMExecutorTest extends BaseTestCase
+{
+    public function testExecuteWithNoPurge(): void
+    {
+        $em = $this->getMockEntityManager();
+        $em->expects($this->once())->method('beginTransaction');
+        $em->expects($this->once())->method('flush');
+        $em->expects($this->once())->method('rollBack');
+        $em->expects($this->once())->method('close');
+
+        $purger = $this->getMockPurger();
+        $purger->expects($this->never())
+            ->method('purge');
+
+        $executor = new DryRunORMExecutor($em, $purger);
+        $fixture  = $this->getMockFixture();
+        $fixture->expects($this->once())
+            ->method('load')
+            ->with($em);
+        $executor->execute([$fixture], true);
+    }
+
+    public function testExecuteWithPurge(): void
+    {
+        $em = $this->getMockEntityManager();
+        $em->expects($this->once())->method('beginTransaction');
+        $em->expects($this->once())->method('flush');
+        $em->expects($this->once())->method('rollBack');
+        $em->expects($this->once())->method('close');
+
+        $purger = $this->getMockPurger();
+        $purger->expects($this->once())
+            ->method('purge');
+
+        $executor = new DryRunORMExecutor($em, $purger);
+        $fixture  = $this->getMockFixture();
+        $fixture->expects($this->once())
+            ->method('load')
+            ->with($em);
+        $executor->execute([$fixture], false);
+    }
+
+    public function testExecuteRollbackOnException(): void
+    {
+        $em = $this->getMockEntityManager();
+        $em->expects($this->once())->method('beginTransaction');
+        $em->expects($this->never())->method('flush');
+        $em->expects($this->once())->method('rollBack');
+        $em->expects($this->once())->method('close');
+
+        $purger = $this->getMockPurger();
+        $purger->expects($this->never())
+            ->method('purge');
+
+        $executor = new DryRunORMExecutor($em, $purger);
+        $fixture  = $this->getMockFixture();
+        $fixture->expects($this->once())
+            ->method('load')
+            ->willThrowException(new RuntimeException());
+
+        $this->expectException(RuntimeException::class);
+        $executor->execute([$fixture], true);
+    }
+
+    private function getMockEntityManager(): EntityManagerInterface&MockObject
+    {
+        $em = $this->getMockSqliteEntityManager();
+
+        return $this->getMockBuilder(EntityManager::class)
+            ->setConstructorArgs([
+                $em->getConnection(),
+                $em->getConfiguration(),
+                $em->getEventManager(),
+            ])
+            ->onlyMethods(['beginTransaction', 'flush', 'rollBack', 'close'])
+            ->getMock();
+    }
+
+    private function getMockFixture(): FixtureInterface&MockObject
+    {
+        return $this->createMock(FixtureInterface::class);
+    }
+
+    private function getMockPurger(): ORMPurgerInterface&MockObject
+    {
+        return $this->createMock(ORMPurgerInterface::class);
+    }
+}


### PR DESCRIPTION
This PR adds the DryRunORMExecutor class, allowing fixtures to be executed in a dry-run mode.

This class is intended to be used by bundles like DoctrineFixturesBundle to provide a --dry-run option.

**Related PR**:

- [DoctrineFixturesBundle PR #512](https://github.com/doctrine/DoctrineFixturesBundle/pull/512)

