### PR TITLE
Remove usage of deprecated method.

### DIFF
--- a/src/Purger/ORMPurger.php
+++ b/src/Purger/ORMPurger.php
@@ -6,6 +6,7 @@ namespace Doctrine\Common\DataFixtures\Purger;
 
 use Doctrine\Common\DataFixtures\Sorter\TopologicalSorter;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\AbstractNamedObject;
 use Doctrine\DBAL\Schema\Identifier;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -13,6 +14,7 @@ use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
 
 use function array_map;
 use function array_reverse;
+use function class_exists;
 use function count;
 use function in_array;
 
@@ -253,6 +255,12 @@ final class ORMPurger implements ORMPurgerInterface
     {
         $tableIdentifier = new Identifier($tableName);
 
-        return 'DELETE FROM ' . $tableIdentifier->getQuotedName($platform);
+        if (class_exists(AbstractNamedObject::class)) {
+            $identifier = $tableIdentifier->getObjectName()->toSQL($platform);
+        } else {
+            $identifier = $tableIdentifier->getQuotedName($platform);
+        }
+
+        return 'DELETE FROM ' . $identifier;
     }
 }

--- a/tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Common\DataFixtures;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\DBAL\Schema\AbstractNamedObject;
 use ReflectionClass;
+
+use function class_exists;
 
 /**
  * Doctrine\Tests\Common\DataFixtures\ORMPurgerTest
@@ -86,6 +89,11 @@ class ORMPurgerTest extends BaseTestCase
         $method    = $class->getMethod('getDeleteFromTableSQL');
         $method->setAccessible(true);
         $sql = $method->invokeArgs($purger, [$tableName, $platform]);
-        $this->assertEquals('DELETE FROM test_schema."group"', $sql);
+
+        if (class_exists(AbstractNamedObject::class)) {
+            $this->assertEquals('DELETE FROM "test_schema"."group"', $sql);
+        } else {
+            $this->assertEquals('DELETE FROM test_schema."group"', $sql);
+        }
     }
 }


### PR DESCRIPTION
\Doctrine\DBAL\Schema\AbstractAsset::getQuotedName Is deprecated since doctrine/dbal 4.3.0.