### PR TITLE
Use Native Lazy Objects with ODM when possible

### DIFF
--- a/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/MongoDBPurgerTest.php
@@ -18,6 +18,8 @@ use function class_exists;
 use function dirname;
 use function method_exists;
 
+use const PHP_VERSION_ID;
+
 class MongoDBPurgerTest extends BaseTestCase
 {
     public const TEST_DOCUMENT_ROLE = Role::class;
@@ -36,6 +38,11 @@ class MongoDBPurgerTest extends BaseTestCase
         $config->setHydratorDir($root . '/generate/hydrators');
         $config->setHydratorNamespace('Hydrators');
         $config->setMetadataDriverImpl(AnnotationDriver::create(dirname(__DIR__) . '/TestDocument'));
+
+        /** @phpstan-ignore function.alreadyNarrowedType (that method exists only since ODM 2.14.0) */
+        if (PHP_VERSION_ID >= 80400 && method_exists($config, 'setUseNativeLazyObject')) {
+            $config->setUseNativeLazyObject(true);
+        }
 
         $dm = DocumentManager::create(null, $config);
 


### PR DESCRIPTION
Not doing so is deprecated.
Note that without this patch, the CI is red.