### PR TITLE
Skip adding dependency if already added

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -158,6 +158,11 @@ class Loader
                     continue;
                 }
 
+                // Skip adding dependency if already added, avoids issues instantiating fixtures which may have dependencies
+                if (isset($this->fixtures[$class])) {
+                    continue;
+                }
+
                 $this->addFixture($this->createFixture($class));
             }
         }

--- a/tests/Common/DataFixtures/LoaderTest.php
+++ b/tests/Common/DataFixtures/LoaderTest.php
@@ -65,8 +65,6 @@ class LoaderTest extends BaseTestCase
 
     /**
      * Test that an error is expected when adding a fixture which requires constructor arguments
-     *
-     * @return void
      */
     public function testAddFixtureWithDependencyError(): void
     {
@@ -77,13 +75,11 @@ class LoaderTest extends BaseTestCase
 
     /**
      * Test that a fixture dependency is not instantiated if it has already been added
-     *
-     * @return void
      */
     public function testAddFixtureWithDependencyPreLoaded(): void
     {
         $fixtureWithConstructor = new FixtureWithConstructorArgs('test');
-        $fixtureWithDependency = new FixtureWithDependency();
+        $fixtureWithDependency  = new FixtureWithDependency();
 
         $loader = new Loader();
         $loader->addFixture($fixtureWithConstructor);
@@ -133,9 +129,6 @@ final class FixtureWithDependency implements DependentFixtureInterface, FixtureI
 
 final class FixtureWithConstructorArgs implements FixtureInterface
 {
-    /**
-     * @param string $requiredArgument
-     */
     public function __construct(private readonly string $requiredArgument)
     {
     }

--- a/tests/Common/DataFixtures/LoaderTest.php
+++ b/tests/Common/DataFixtures/LoaderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\DataFixtures;
 
+use ArgumentCountError;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\ReferenceRepository;
@@ -60,6 +62,36 @@ class LoaderTest extends BaseTestCase
 
         $this->assertInstanceOf(MyFixture1::class, $fixture);
     }
+
+
+    /**
+     * Test that an error is expected when adding a fixture which requires constructor arguments
+     *
+     * @return void
+     */
+    public function testAddFixtureWithDependencyError()
+    {
+        $loader = new Loader();
+        $this->expectException(ArgumentCountError::class);
+        $loader->addFixture(new FixtureWithDependency());
+    }
+
+    /**
+     * Test that a fixture dependency is not instantiated if it has already been added
+     *
+     * @return void
+     */
+    public function testAddFixtureWithDependencyPreLoaded()
+    {
+        $fixtureWithConstructor = new FixtureWithConstructorArgs('test');
+        $fixtureWithDependency = new FixtureWithDependency();
+
+        $loader = new Loader();
+        $loader->addFixture($fixtureWithConstructor);
+        $loader->addFixture($fixtureWithDependency);
+
+        $this->assertSame([$fixtureWithConstructor, $fixtureWithDependency], $loader->getFixtures());
+    }
 }
 
 final class DummyFixtureOne implements FixtureInterface
@@ -83,6 +115,35 @@ final class SharedDummyFixture implements SharedFixtureInterface
     }
 
     public function setReferenceRepository(ReferenceRepository $referenceRepository): void
+    {
+    }
+}
+
+final class FixtureWithDependency implements DependentFixtureInterface, FixtureInterface
+{
+
+    public function load(ObjectManager $manager): void
+    {
+    }
+
+    public function getDependencies(): array
+    {
+        return [FixtureWithConstructorArgs::class];
+    }
+}
+
+final class FixtureWithConstructorArgs implements FixtureInterface
+{
+
+    /**
+     * @param string $requiredArgument
+     * @noinspection PhpPropertyOnlyWrittenInspection
+     */
+    public function __construct(private readonly string $requiredArgument)
+    {
+    }
+
+    public function load(ObjectManager $manager): void
     {
     }
 }

--- a/tests/Common/DataFixtures/LoaderTest.php
+++ b/tests/Common/DataFixtures/LoaderTest.php
@@ -63,13 +63,12 @@ class LoaderTest extends BaseTestCase
         $this->assertInstanceOf(MyFixture1::class, $fixture);
     }
 
-
     /**
      * Test that an error is expected when adding a fixture which requires constructor arguments
      *
      * @return void
      */
-    public function testAddFixtureWithDependencyError()
+    public function testAddFixtureWithDependencyError(): void
     {
         $loader = new Loader();
         $this->expectException(ArgumentCountError::class);
@@ -81,7 +80,7 @@ class LoaderTest extends BaseTestCase
      *
      * @return void
      */
-    public function testAddFixtureWithDependencyPreLoaded()
+    public function testAddFixtureWithDependencyPreLoaded(): void
     {
         $fixtureWithConstructor = new FixtureWithConstructorArgs('test');
         $fixtureWithDependency = new FixtureWithDependency();
@@ -91,6 +90,7 @@ class LoaderTest extends BaseTestCase
         $loader->addFixture($fixtureWithDependency);
 
         $this->assertSame([$fixtureWithConstructor, $fixtureWithDependency], $loader->getFixtures());
+        $this->assertSame('test', $fixtureWithConstructor->getRequiredArgument());
     }
 }
 
@@ -121,7 +121,6 @@ final class SharedDummyFixture implements SharedFixtureInterface
 
 final class FixtureWithDependency implements DependentFixtureInterface, FixtureInterface
 {
-
     public function load(ObjectManager $manager): void
     {
     }
@@ -134,10 +133,8 @@ final class FixtureWithDependency implements DependentFixtureInterface, FixtureI
 
 final class FixtureWithConstructorArgs implements FixtureInterface
 {
-
     /**
      * @param string $requiredArgument
-     * @noinspection PhpPropertyOnlyWrittenInspection
      */
     public function __construct(private readonly string $requiredArgument)
     {
@@ -145,5 +142,10 @@ final class FixtureWithConstructorArgs implements FixtureInterface
 
     public function load(ObjectManager $manager): void
     {
+    }
+
+    public function getRequiredArgument(): string
+    {
+        return $this->requiredArgument;
     }
 }


### PR DESCRIPTION
Skip adding dependency if already added, avoids issues instantiating fixtures which may have dependencies.