### PR TITLE
Remove calls to setAccessible

### DIFF
--- a/tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -23,72 +23,65 @@ class ORMPurgerTest extends BaseTestCase
 
     public function testGetAssociationTables(): void
     {
-        $em       = $this->getMockSqliteEntityManager();
-        $metadata = $em->getClassMetadata(self::TEST_ENTITY_USER);
-        $platform = $em->getConnection()->getDatabasePlatform();
-        $purger   = new ORMPurger($em);
-        $class    = new ReflectionClass(ORMPurger::class);
-        $method   = $class->getMethod('getAssociationTables');
-        $method->setAccessible(true);
+        $em                = $this->getMockSqliteEntityManager();
+        $metadata          = $em->getClassMetadata(self::TEST_ENTITY_USER);
+        $platform          = $em->getConnection()->getDatabasePlatform();
+        $purger            = new ORMPurger($em);
+        $class             = new ReflectionClass(ORMPurger::class);
+        $method            = $class->getMethod('getAssociationTables');
         $associationTables = $method->invokeArgs($purger, [[$metadata], $platform]);
         $this->assertEquals('readers.author_reader', $associationTables[0]);
     }
 
     public function testGetAssociationTablesQuoted(): void
     {
-        $em       = $this->getMockSqliteEntityManager();
-        $metadata = $em->getClassMetadata(self::TEST_ENTITY_QUOTED);
-        $platform = $em->getConnection()->getDatabasePlatform();
-        $purger   = new ORMPurger($em);
-        $class    = new ReflectionClass(ORMPurger::class);
-        $method   = $class->getMethod('getAssociationTables');
-        $method->setAccessible(true);
+        $em                = $this->getMockSqliteEntityManager();
+        $metadata          = $em->getClassMetadata(self::TEST_ENTITY_QUOTED);
+        $platform          = $em->getConnection()->getDatabasePlatform();
+        $purger            = new ORMPurger($em);
+        $class             = new ReflectionClass(ORMPurger::class);
+        $method            = $class->getMethod('getAssociationTables');
         $associationTables = $method->invokeArgs($purger, [[$metadata], $platform]);
         $this->assertEquals($associationTables[0], '"INSERT"');
     }
 
     public function testTableNameWithSchema(): void
     {
-        $em       = $this->getMockSqliteEntityManager();
-        $metadata = $em->getClassMetadata(self::TEST_ENTITY_USER_WITH_SCHEMA);
-        $platform = $em->getConnection()->getDatabasePlatform();
-        $purger   = new ORMPurger($em);
-        $class    = new ReflectionClass(ORMPurger::class);
-        $method   = $class->getMethod('getTableName');
-        $method->setAccessible(true);
+        $em        = $this->getMockSqliteEntityManager();
+        $metadata  = $em->getClassMetadata(self::TEST_ENTITY_USER_WITH_SCHEMA);
+        $platform  = $em->getConnection()->getDatabasePlatform();
+        $purger    = new ORMPurger($em);
+        $class     = new ReflectionClass(ORMPurger::class);
+        $method    = $class->getMethod('getTableName');
         $tableName = $method->invokeArgs($purger, [$metadata, $platform]);
         $this->assertStringStartsWith('test_schema', $tableName);
     }
 
     public function testGetDeleteFromTableSQL(): void
     {
-        $em       = $this->getMockSqliteEntityManager();
-        $metadata = $em->getClassMetadata(self::TEST_ENTITY_GROUP);
-        $platform = $em->getConnection()->getDatabasePlatform();
-        $purger   = new ORMPurger($em);
-        $class    = new ReflectionClass(ORMPurger::class);
-        $method   = $class->getMethod('getTableName');
-        $method->setAccessible(true);
+        $em        = $this->getMockSqliteEntityManager();
+        $metadata  = $em->getClassMetadata(self::TEST_ENTITY_GROUP);
+        $platform  = $em->getConnection()->getDatabasePlatform();
+        $purger    = new ORMPurger($em);
+        $class     = new ReflectionClass(ORMPurger::class);
+        $method    = $class->getMethod('getTableName');
         $tableName = $method->invokeArgs($purger, [$metadata, $platform]);
         $method    = $class->getMethod('getDeleteFromTableSQL');
-        $method->setAccessible(true);
-        $sql = $method->invokeArgs($purger, [$tableName, $platform]);
+        $sql       = $method->invokeArgs($purger, [$tableName, $platform]);
         $this->assertEquals('DELETE FROM "Group"', $sql);
     }
 
     public function testGetDeleteFromTableSQLWithSchema(): void
     {
-        $em       = $this->getMockSqliteEntityManager();
-        $metadata = $em->getClassMetadata(self::TEST_ENTITY_GROUP_WITH_SCHEMA);
-        $platform = $em->getConnection()->getDatabasePlatform();
-        $purger   = new ORMPurger($em);
-        $class    = new ReflectionClass(ORMPurger::class);
-        $method   = $class->getMethod('getTableName');
-        $method->setAccessible(true);
+        $em        = $this->getMockSqliteEntityManager();
+        $metadata  = $em->getClassMetadata(self::TEST_ENTITY_GROUP_WITH_SCHEMA);
+        $platform  = $em->getConnection()->getDatabasePlatform();
+        $purger    = new ORMPurger($em);
+        $class     = new ReflectionClass(ORMPurger::class);
+        $method    = $class->getMethod('getTableName');
         $tableName = $method->invokeArgs($purger, [$metadata, $platform]);
         $method    = $class->getMethod('getDeleteFromTableSQL');
-        $method->setAccessible(true);
-        $sql = $method->invokeArgs($purger, [$tableName, $platform]);
+        $sql       = $method->invokeArgs($purger, [$tableName, $platform]);
 
         if (class_exists(AbstractNamedObject::class)) {
             $this->assertEquals('DELETE FROM "test_schema"."group"', $sql);


### PR DESCRIPTION
The method is a noop since PHP 8.1 and was deprecated in PHP 8.5.

Fixes: #611